### PR TITLE
Bot.OnMessage receives BotMessages, Attachments

### DIFF
--- a/SlackNet.Bot/SlackBot.cs
+++ b/SlackNet.Bot/SlackBot.cs
@@ -168,7 +168,7 @@ namespace SlackNet.Bot
             _api = apiClient;
             _scheduler = scheduler ?? Scheduler.Default;
             _incomingWithMiddlewareApplied = _rtm.Messages
-                .Where(m => m.GetType() == typeof(MessageEvent))
+                .Where(m => m.GetType() == typeof(MessageEvent) || m.GetType() == typeof(SlackNet.Events.BotMessage))
                 .Where(m => m.User != Id)
                 .SelectMany(CreateSlackMessage);
             _outgoingWithMiddlewareApplied = _outgoingMessages
@@ -264,7 +264,7 @@ namespace SlackNet.Bot
         /// Get information on a public or private channel, IM, or multi-person IM.
         /// </summary>
         public async Task<Hub> GetHubById(string hubId) =>
-            hubId == null
+            String.IsNullOrEmpty(hubId)
                 ? null
                 : await _hubs.GetOrAdd(hubId, FetchHub).ConfigureAwait(false);
 
@@ -375,7 +375,7 @@ namespace SlackNet.Bot
         /// Get user information.
         /// </summary>
         public async Task<User> GetUserById(string userId) =>
-            userId == null
+            String.IsNullOrEmpty(userId)
                 ? null
                 : await _users.GetOrAdd(userId, _ => _api.Users.Info(userId).NullIfNotFound()).ConfigureAwait(false);
 

--- a/SlackNet/Events/Messages/MessageEvent.cs
+++ b/SlackNet/Events/Messages/MessageEvent.cs
@@ -17,7 +17,7 @@ namespace SlackNet.Events
         public string ThreadTs { get; set; }
         [JsonIgnore]
         public DateTime? ThreadTimestamp => ThreadTs.ToDateTime();
-        public IList<Attachment> Attachments { get; } = new List<Attachment>();
+        public IList<Attachment> Attachments { get; set; } = new List<Attachment>();
         public Edit Edited { get; set; }
         /// <summary>
         /// Indicates message is part of the history of a channel but should not be displayed to users.


### PR DESCRIPTION
Three small fixes:
- Bot Messages where not received in `Bot.OnMessage` Event
- Attachments where Always null (not deserialized: missing setter)
- possible NRE-Exception when User or Hub in Event Message is empty instead of null.


fixes #4 and #5 