### PR TITLE
fix missing setter in ImListResponse, possible NRE

### DIFF
--- a/SlackNet.Bot/SlackMessage.cs
+++ b/SlackNet.Bot/SlackMessage.cs
@@ -27,7 +27,7 @@ namespace SlackNet.Bot
         public bool IsInThread => ThreadTs != null;
         public bool MentionsBot => Text.IndexOf(_bot.Id, StringComparison.OrdinalIgnoreCase) >= 0
             || Text.IndexOf(_bot.Name, StringComparison.OrdinalIgnoreCase) >= 0
-            || Hub.IsIm;
+            || Hub?.IsIm == true;
 
         public Task ReplyWith(string text, bool createThread = false) => ReplyWith(new BotMessage { Text = text }, createThread);
 

--- a/SlackNet/WebApi/Responses/ImListResponse.cs
+++ b/SlackNet/WebApi/Responses/ImListResponse.cs
@@ -4,6 +4,6 @@ namespace SlackNet.WebApi
 {
     class ImListResponse
     {
-        public List<Im> Ims { get; } = new List<Im>();
+        public List<Im> Ims { get; set; } = new List<Im>();
     }
 }


### PR DESCRIPTION
Hi there, thanks for the quick Integration last time. This time, I found a similar Problem in `im.list()` (`ImListResponse.Ims`: missing setter) deserialization, causing a NRE when `IMessage.MentionsBot` is called.

fixes #7 