### PR TITLE
WebApi: Changed HTTP methods

### DIFF
--- a/SlackNet.Tests/ApiLintTest.cs
+++ b/SlackNet.Tests/ApiLintTest.cs
@@ -140,6 +140,9 @@ namespace SlackNet.Tests
                 return Task.FromResult(0);
             }
 
+            public Task Post(string apiMethod, Args args, CancellationToken? cancellationToken) =>
+                Post<object>(apiMethod, args, cancellationToken);
+
             public Task<T> Post<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class
             {
                 HttpMethod = "POST";

--- a/SlackNet.Tests/ApiLintTest.cs
+++ b/SlackNet.Tests/ApiLintTest.cs
@@ -140,6 +140,15 @@ namespace SlackNet.Tests
                 return Task.FromResult(0);
             }
 
+            public Task<T> Post<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class
+            {
+                HttpMethod = "POST";
+                SlackMethod = apiMethod;
+                Args = args;
+                CancellationToken = cancellationToken;
+                return Task.FromResult(Activator.CreateInstance<T>());
+            }
+
             public Task<T> Post<T>(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken) where T : class
             {
                 HttpMethod = "POST";

--- a/SlackNet/Http.cs
+++ b/SlackNet/Http.cs
@@ -8,8 +8,7 @@ namespace SlackNet
 {
     public interface IHttp
     {
-        Task<T> Get<T>(string url, CancellationToken? cancellationToken = null);
-        Task<T> Post<T>(string url, HttpContent content, CancellationToken? cancellationToken = null);
+        Task<T> Execute<T>(HttpRequestMessage requestMessage, CancellationToken? cancellationToken = null);
     }
 
     class Http : IHttp
@@ -23,16 +22,9 @@ namespace SlackNet
             _jsonSettings = jsonSettings;
         }
 
-        public async Task<T> Get<T>(string url, CancellationToken? cancellationToken = null)
+        public async Task<T> Execute<T>(HttpRequestMessage requestMessage, CancellationToken? cancellationToken = null)
         {
-            var response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
-            return await Deserialize<T>(response).ConfigureAwait(false);
-        }
-
-        public async Task<T> Post<T>(string url, HttpContent content, CancellationToken? cancellationToken = null)
-        {
-            var response = await _client.PostAsync(url, content, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
+            var response = await _client.SendAsync(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return await Deserialize<T>(response).ConfigureAwait(false);
         }

--- a/SlackNet/SlackApiClient.cs
+++ b/SlackNet/SlackApiClient.cs
@@ -62,19 +62,27 @@ namespace SlackNet
         /// Calls a Slack API that requires POST content.
         /// </summary>
         /// <param name="apiMethod">Name of Slack method.</param>
-        /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
-        /// <param name="content">POST body content. Should be either <see cref="FormUrlEncodedContent"/> or <see cref="MultipartFormDataContent"/>.</param>
+        /// <param name="args">Arguments to send to Slack. Authorization headers will be added automatically.</param>
         /// <param name="cancellationToken"></param>
-        Task Post(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken);
-
+        Task Post(string apiMethod, Args args, CancellationToken? cancellationToken);
+        
         /// <summary>
         /// Calls a Slack API that requires POST content.
         /// </summary>
         /// <typeparam name="T">Type of response expected.</typeparam>
         /// <param name="apiMethod">Name of Slack method.</param>
-        /// <param name="args">Arguments to send to Slack. Authorization headers will be added automagically.</param>
+        /// <param name="args">Arguments to send to Slack. Authorization headers will be added automatically.</param>
         /// <param name="cancellationToken"></param>
         Task<T> Post<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class;
+        
+        /// <summary>
+        /// Calls a Slack API that requires POST content.
+        /// </summary>
+        /// <param name="apiMethod">Name of Slack method.</param>
+        /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
+        /// <param name="content">POST body content. Should be either <see cref="FormUrlEncodedContent"/> or <see cref="MultipartFormDataContent"/>.</param>
+        /// <param name="cancellationToken"></param>
+        Task Post(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken);
         
         /// <summary>
         /// Calls a Slack API that requires POST content.
@@ -161,17 +169,15 @@ namespace SlackNet
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, Url(apiMethod, args));
             return Deserialize<T>(await _http.Execute<WebApiResponse>(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false));
         }
-            
-
+        
         /// <summary>
         /// Calls a Slack API that requires POST content.
         /// </summary>
         /// <param name="apiMethod">Name of Slack method.</param>
         /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
-        /// <param name="content">POST body content. Should be either <see cref="FormUrlEncodedContent"/> or <see cref="MultipartFormDataContent"/>.</param>
         /// <param name="cancellationToken"></param>
-        public Task Post(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken) =>
-            Post<object>(apiMethod, args, content, cancellationToken);
+        public Task Post(string apiMethod, Args args, CancellationToken? cancellationToken) =>
+            Post<object>(apiMethod, args, cancellationToken);
 
         /// <summary>
         /// Calls a Slack API that requires POST content.
@@ -189,6 +195,16 @@ namespace SlackNet
             var response = await _http.Execute<WebApiResponse>(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
             return Deserialize<T>(response);
         }
+
+        /// <summary>
+        /// Calls a Slack API that requires POST content.
+        /// </summary>
+        /// <param name="apiMethod">Name of Slack method.</param>
+        /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
+        /// <param name="content">POST body content. Should be either <see cref="FormUrlEncodedContent"/> or <see cref="MultipartFormDataContent"/>.</param>
+        /// <param name="cancellationToken"></param>
+        public Task Post(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken) =>
+            Post<object>(apiMethod, args, content, cancellationToken);
 
         /// <summary>
         /// Calls a Slack API that requires POST content.

--- a/SlackNet/SlackApiClient.cs
+++ b/SlackNet/SlackApiClient.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -65,6 +67,15 @@ namespace SlackNet
         /// <param name="cancellationToken"></param>
         Task Post(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken);
 
+        /// <summary>
+        /// Calls a Slack API that requires POST content.
+        /// </summary>
+        /// <typeparam name="T">Type of response expected.</typeparam>
+        /// <param name="apiMethod">Name of Slack method.</param>
+        /// <param name="args">Arguments to send to Slack. Authorization headers will be added automagically.</param>
+        /// <param name="cancellationToken"></param>
+        Task<T> Post<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class;
+        
         /// <summary>
         /// Calls a Slack API that requires POST content.
         /// </summary>
@@ -145,8 +156,12 @@ namespace SlackNet
         /// <param name="apiMethod">Name of Slack method.</param>
         /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
         /// <param name="cancellationToken"></param>
-        public async Task<T> Get<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class =>
-            Deserialize<T>(await _http.Get<WebApiResponse>(Url(apiMethod, args), cancellationToken ?? CancellationToken.None).ConfigureAwait(false));
+        public async Task<T> Get<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, Url(apiMethod, args));
+            return Deserialize<T>(await _http.Execute<WebApiResponse>(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false));
+        }
+            
 
         /// <summary>
         /// Calls a Slack API that requires POST content.
@@ -164,11 +179,34 @@ namespace SlackNet
         /// <typeparam name="T">Type of response expected.</typeparam>
         /// <param name="apiMethod">Name of Slack method.</param>
         /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
+        /// <param name="cancellationToken"></param>
+        public async Task<T> Post<T>(string apiMethod, Args args, CancellationToken? cancellationToken) where T : class
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post,Url(apiMethod));
+            requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            requestMessage.Content = new StringContent(JsonConvert.SerializeObject(args, _jsonSettings.SerializerSettings), Encoding.UTF8, "application/json");
+
+            var response = await _http.Execute<WebApiResponse>(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
+            return Deserialize<T>(response);
+        }
+
+        /// <summary>
+        /// Calls a Slack API that requires POST content.
+        /// </summary>
+        /// <typeparam name="T">Type of response expected.</typeparam>
+        /// <param name="apiMethod">Name of Slack method.</param>
+        /// <param name="args">Arguments to send to Slack. The "token" parameter will be filled in automatically.</param>
         /// <param name="content">POST body content. Should be either <see cref="FormUrlEncodedContent"/> or <see cref="MultipartFormDataContent"/>.</param>
         /// <param name="cancellationToken"></param>
-        public async Task<T> Post<T>(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken) where T : class =>
-            Deserialize<T>(await _http.Post<WebApiResponse>(Url(apiMethod, args), content, cancellationToken ?? CancellationToken.None).ConfigureAwait(false));
-
+        public async Task<T> Post<T>(string apiMethod, Args args, HttpContent content, CancellationToken? cancellationToken) where T : class
+        {
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, Url(apiMethod, args)) { Content = content };
+            return Deserialize<T>(await _http.Execute<WebApiResponse>(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false));
+        }
+            
+        private string Url(string apiMethod) =>
+            _urlBuilder.Url(apiMethod, new Args());
+        
         private string Url(string apiMethod, Args args)
         {
             if (!args.ContainsKey("token"))

--- a/SlackNet/WebApi/ApiApi.cs
+++ b/SlackNet/WebApi/ApiApi.cs
@@ -38,7 +38,7 @@ namespace SlackNet.WebApi
         public async Task<IReadOnlyDictionary<string, string>> Test(string error, Args args, CancellationToken? cancellationToken = null)
         {
             var query = new Args(args) { ["error"] = error };
-            return (await _client.Get<TestResponse>("api.test", query, cancellationToken).ConfigureAwait(false)).Args;
+            return (await _client.Post<TestResponse>("api.test", query, cancellationToken).ConfigureAwait(false)).Args;
         }
     }
 }

--- a/SlackNet/WebApi/AuthApi.cs
+++ b/SlackNet/WebApi/AuthApi.cs
@@ -40,6 +40,6 @@ namespace SlackNet.WebApi
         /// Checks authentication and tells you who you are.
         /// </summary>
         public Task<AuthTestResponse> Test(CancellationToken? cancellationToken = null) =>
-            _client.Get<AuthTestResponse>("auth.test", new Args(), cancellationToken);
+            _client.Post<AuthTestResponse>("auth.test", new Args(), cancellationToken);
     }
 }

--- a/SlackNet/WebApi/ChannelsApi.cs
+++ b/SlackNet/WebApi/ChannelsApi.cs
@@ -162,7 +162,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Archive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("channels.archive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("channels.archive", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Used to create a channel.
@@ -253,7 +253,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">User to remove from channel.</param>
         /// <param name="cancellationToken"></param>
         public Task Kick(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("channels.kick", new Args
+            _client.Post("channels.kick", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -266,7 +266,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Leave(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("channels.leave", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("channels.leave", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a list of all channels in the team. 
@@ -292,7 +292,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("channels.mark", new Args
+            _client.Post("channels.mark", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts }
@@ -366,6 +366,6 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Channel to unarchive.</param>
         /// <param name="cancellationToken"></param>
         public Task Unarchive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("channels.unarchive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("channels.unarchive", new Args { { "channel", channelId } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/ChannelsApi.cs
+++ b/SlackNet/WebApi/ChannelsApi.cs
@@ -162,7 +162,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Archive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("channels.archive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("channels.archive", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Used to create a channel.
@@ -172,7 +172,7 @@ namespace SlackNet.WebApi
         /// <param name="validate">Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Create(string name, bool validate = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ChannelResponse>("channels.create", new Args
+            (await _client.Post<ChannelResponse>("channels.create", new Args
                 {
                     { "name", name },
                     { "validate", validate }
@@ -220,7 +220,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">User to invite to channel.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Invite(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ChannelResponse>("channels.invite", new Args
+            (await _client.Post<ChannelResponse>("channels.invite", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -240,7 +240,7 @@ namespace SlackNet.WebApi
         /// This allows a client to see that the request to join GeNERaL is the same as the channel #general that the user is already in.
         /// </returns>
         public Task<ChannelJoinResponse> Join(string channelName, bool validate = false, CancellationToken? cancellationToken = null) =>
-            _client.Get<ChannelJoinResponse>("channels.join", new Args
+            _client.Post<ChannelJoinResponse>("channels.join", new Args
                 {
                     { "channel", channelName },
                     { "validate", validate }
@@ -253,7 +253,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">User to remove from channel.</param>
         /// <param name="cancellationToken"></param>
         public Task Kick(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            _client.Get("channels.kick", new Args
+            _client.Post<object>("channels.kick", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -266,7 +266,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Leave(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("channels.leave", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("channels.leave", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a list of all channels in the team. 
@@ -292,7 +292,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("channels.mark", new Args
+            _client.Post<object>("channels.mark", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts }
@@ -308,7 +308,7 @@ namespace SlackNet.WebApi
         /// <param name="validate">Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Rename(string channelId, string name, bool validate = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ChannelResponse>("channels.rename", new Args
+            (await _client.Post<ChannelResponse>("channels.rename", new Args
                 {
                     { "channel", channelId },
                     { "name", name },
@@ -338,7 +338,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns>The channel's new purpose.</returns>
         public async Task<string> SetPurpose(string channelId, string purpose, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<PurposeResponse>("channels.setPurpose", new Args
+            (await _client.Post<PurposeResponse>("channels.setPurpose", new Args
                 {
                     { "channel", channelId },
                     { "purpose", purpose }
@@ -353,7 +353,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns>The channel's new topic.</returns>
         public async Task<string> SetTopic(string channelId, string topic, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<TopicResponse>("channels.setTopic", new Args
+            (await _client.Post<TopicResponse>("channels.setTopic", new Args
                 {
                     { "channel", channelId },
                     { "topic", topic }
@@ -366,6 +366,6 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Channel to unarchive.</param>
         /// <param name="cancellationToken"></param>
         public Task Unarchive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("channels.unarchive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("channels.unarchive", new Args { { "channel", channelId } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/ChatApi.cs
+++ b/SlackNet/WebApi/ChatApi.cs
@@ -116,7 +116,7 @@ namespace SlackNet.WebApi
         /// <param name="message">The message to post.</param>
         /// <param name="cancellationToken"></param>
         public Task<PostMessageResponse> PostMessage(Message message, CancellationToken? cancellationToken = null) =>
-            _client.Get<PostMessageResponse>("chat.postMessage", PopulateMessageArgs(message, new Args()),
+            _client.Post<PostMessageResponse>("chat.postMessage", PopulateMessageArgs(message, new Args()),
                 cancellationToken);
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace SlackNet.WebApi
         /// <param name="message">The message to post. Not all message properties are supported by <c>PostEphemeral</c>.</param>
         /// <param name="cancellationToken"></param>
         public Task<PostMessageResponse> PostEphemeral(string userId, Message message, CancellationToken? cancellationToken = null) =>
-            _client.Get<PostMessageResponse>("chat.postEphemeral", new Args
+            _client.Post<PostMessageResponse>("chat.postEphemeral", new Args
                     {
                         { "channel", message.Channel },
                         { "text", message.Text },

--- a/SlackNet/WebApi/ChatApi.cs
+++ b/SlackNet/WebApi/ChatApi.cs
@@ -186,7 +186,7 @@ namespace SlackNet.WebApi
         /// Subsequent attempts with the same <see cref="ts"/> and <see cref="channelId"/> values will modify the same attachments, rather than adding more.
         /// </remarks>
         public Task Unfurl(string channelId, string ts, IDictionary<string, Attachment> unfurls, bool userAuthRequired = false, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("chat.unfurl", new Args
+            _client.Post("chat.unfurl", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts },

--- a/SlackNet/WebApi/ChatApi.cs
+++ b/SlackNet/WebApi/ChatApi.cs
@@ -77,7 +77,7 @@ namespace SlackNet.WebApi
         /// <param name="asUser">Pass True to delete the message as the authed user. Bot users in this context are considered authed users.</param>
         /// <param name="cancellationToken"></param>
         public Task<MessageTsResponse> Delete(string ts, string channelId, bool asUser = false, CancellationToken? cancellationToken = null) =>
-            _client.Get<MessageTsResponse>("chat.delete", new Args
+            _client.Post<MessageTsResponse>("chat.delete", new Args
                 {
                     { "ts", ts },
                     { "channel", channelId },
@@ -104,7 +104,7 @@ namespace SlackNet.WebApi
         /// <param name="text">Text of the message to send.</param>
         /// <param name="cancellationToken"></param>
         public Task<MessageTsResponse> MeMessage(string channel, string text, CancellationToken? cancellationToken = null) =>
-            _client.Get<MessageTsResponse>("chat.meMessage", new Args
+            _client.Post<MessageTsResponse>("chat.meMessage", new Args
                 {
                     { "channel", channel },
                     { "text", text }
@@ -126,7 +126,7 @@ namespace SlackNet.WebApi
         /// <param name="postAt">Time in the future to send the message.</param>
         /// <param name="cancellationToken"></param>
         public Task<ScheduleMessageResponse> ScheduleMessage(Message message, DateTime postAt, CancellationToken? cancellationToken = null) =>
-            _client.Get<ScheduleMessageResponse>("chat.scheduleMessage", PopulateMessageArgs(message, new Args
+            _client.Post<ScheduleMessageResponse>("chat.scheduleMessage", PopulateMessageArgs(message, new Args
                     {
                         { "post_at", postAt.ToTimestamp() }
                     }),
@@ -186,7 +186,7 @@ namespace SlackNet.WebApi
         /// Subsequent attempts with the same <see cref="ts"/> and <see cref="channelId"/> values will modify the same attachments, rather than adding more.
         /// </remarks>
         public Task Unfurl(string channelId, string ts, IDictionary<string, Attachment> unfurls, bool userAuthRequired = false, CancellationToken? cancellationToken = null) =>
-            _client.Get("chat.unfurl", new Args
+            _client.Post<object>("chat.unfurl", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts },
@@ -200,7 +200,7 @@ namespace SlackNet.WebApi
         /// <param name="messageUpdate">Message to update.</param>
         /// <param name="cancellationToken"></param>
         public Task<MessageUpdateResponse> Update(MessageUpdate messageUpdate, CancellationToken? cancellationToken = null) =>
-            _client.Get<MessageUpdateResponse>("chat.update", new Args
+            _client.Post<MessageUpdateResponse>("chat.update", new Args
                     {
                         { "ts", messageUpdate.Ts },
                         { "channel", messageUpdate.ChannelId },

--- a/SlackNet/WebApi/ConversationsApi.cs
+++ b/SlackNet/WebApi/ConversationsApi.cs
@@ -207,7 +207,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">ID of conversation to archive.</param>
         /// <param name="cancellationToken"></param>
         public Task Archive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("conversations.archive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("conversations.archive", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Closes a direct message or multi-person direct message.
@@ -216,7 +216,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Close(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("conversations.close", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("conversations.close", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Initiates a public or private channel-based conversation.
@@ -303,7 +303,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">User ID to be removed.</param>
         /// <param name="cancellationToken"></param>
         public Task Kick(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("conversations.kick", new Args
+            _client.Post("conversations.kick", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -315,7 +315,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Conversation to leave.</param>
         /// <param name="cancellationToken"></param>
         public Task Leave(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("conversations.leave", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("conversations.leave", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Lists all channels in a Slack team.
@@ -478,6 +478,6 @@ namespace SlackNet.WebApi
         /// <param name="channelId">ID of conversation to unarchive.</param>
         /// <param name="cancellationToken"></param>
         public Task Unarchive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("conversations.unarchive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("conversations.unarchive", new Args { { "channel", channelId } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/ConversationsApi.cs
+++ b/SlackNet/WebApi/ConversationsApi.cs
@@ -207,7 +207,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">ID of conversation to archive.</param>
         /// <param name="cancellationToken"></param>
         public Task Archive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("conversations.archive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("conversations.archive", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Closes a direct message or multi-person direct message.
@@ -216,7 +216,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Close(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("conversations.close", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("conversations.close", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Initiates a public or private channel-based conversation.
@@ -226,7 +226,7 @@ namespace SlackNet.WebApi
         /// <param name="isPrivate">Create a private channel instead of a public one.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Conversation> Create(string name, bool isPrivate, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ConversationResponse>("conversations.create", new Args
+            (await _client.Post<ConversationResponse>("conversations.create", new Args
                 {
                     { "name", name },
                     { "is_private", isPrivate }
@@ -281,7 +281,7 @@ namespace SlackNet.WebApi
         /// <param name="userIds">A comma separated list of user IDs. Up to 30 users may be listed.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Conversation> Invite(string channelId, IEnumerable<string> userIds, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ConversationResponse>("conversations.invite", new Args
+            (await _client.Post<ConversationResponse>("conversations.invite", new Args
                 {
                     { "channel", channelId },
                     { "users", userIds }
@@ -294,7 +294,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">ID of conversation to join.</param>
         /// <param name="cancellationToken"></param>
         public Task<ConversationJoinResponse> Join(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get<ConversationJoinResponse>("conversations.join", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<ConversationJoinResponse>("conversations.join", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Removes a user from a conversation.
@@ -303,7 +303,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">User ID to be removed.</param>
         /// <param name="cancellationToken"></param>
         public Task Kick(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            _client.Get("conversations.kick", new Args
+            _client.Post<object>("conversations.kick", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -315,7 +315,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Conversation to leave.</param>
         /// <param name="cancellationToken"></param>
         public Task Leave(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("conversations.leave", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("conversations.leave", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Lists all channels in a Slack team.
@@ -396,7 +396,7 @@ namespace SlackNet.WebApi
             Open<ImResponse>(true, null, userIds, cancellationToken);
 
         private Task<T> Open<T>(bool returnIm, string channelId = null, IEnumerable<string> userIds = null, CancellationToken? cancellationToken = null) where T : class =>
-            _client.Get<T>("conversations.open", new Args
+            _client.Post<T>("conversations.open", new Args
                 {
                     { "channel", channelId },
                     { "return_im", returnIm },
@@ -410,7 +410,7 @@ namespace SlackNet.WebApi
         /// <param name="name">New name for conversation.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Conversation> Rename(string channelId, string name, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ConversationResponse>("conversations.rename", new Args
+            (await _client.Post<ConversationResponse>("conversations.rename", new Args
                 {
                     { "channel", channelId },
                     { "name", name }
@@ -451,7 +451,7 @@ namespace SlackNet.WebApi
         /// <param name="purpose">A new, specialer purpose.</param>
         /// <param name="cancellationToken"></param>
         public async Task<string> SetPurpose(string channelId, string purpose, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<PurposeResponse>("conversations.setPurpose", new Args
+            (await _client.Post<PurposeResponse>("conversations.setPurpose", new Args
                 {
                     { "channel", channelId },
                     { "purpose", purpose }
@@ -465,7 +465,7 @@ namespace SlackNet.WebApi
         /// <param name="topic">The new topic string. Does not support formatting or linkification.</param>
         /// <param name="cancellationToken"></param>
         public async Task<string> SetTopic(string channelId, string topic, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<TopicResponse>("conversations.setTopic", new Args
+            (await _client.Post<TopicResponse>("conversations.setTopic", new Args
                 {
                     { "channel", channelId },
                     { "topic", topic }
@@ -478,6 +478,6 @@ namespace SlackNet.WebApi
         /// <param name="channelId">ID of conversation to unarchive.</param>
         /// <param name="cancellationToken"></param>
         public Task Unarchive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("conversations.unarchive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("conversations.unarchive", new Args { { "channel", channelId } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/DialogApi.cs
+++ b/SlackNet/WebApi/DialogApi.cs
@@ -28,7 +28,7 @@ namespace SlackNet.WebApi
         /// <param name="dialog">The dialog definition.</param>
         /// <param name="cancellationToken"></param>
         public Task Open(string triggerId, Dialog dialog, CancellationToken? cancellationToken = null) =>
-            _client.Get("dialog.open", new Args
+            _client.Post<object>("dialog.open", new Args
                 {
                     { "dialog", dialog },
                     { "trigger_id", triggerId }

--- a/SlackNet/WebApi/DialogApi.cs
+++ b/SlackNet/WebApi/DialogApi.cs
@@ -28,7 +28,7 @@ namespace SlackNet.WebApi
         /// <param name="dialog">The dialog definition.</param>
         /// <param name="cancellationToken"></param>
         public Task Open(string triggerId, Dialog dialog, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("dialog.open", new Args
+            _client.Post("dialog.open", new Args
                 {
                     { "dialog", dialog },
                     { "trigger_id", triggerId }

--- a/SlackNet/WebApi/DndApi.cs
+++ b/SlackNet/WebApi/DndApi.cs
@@ -59,14 +59,14 @@ namespace SlackNet.WebApi
         /// </summary>
         /// <param name="cancellationToken"></param>
         public Task EndDnd(CancellationToken? cancellationToken = null) =>
-            _client.Get("dnd.endDnd", new Args(), cancellationToken);
+            _client.Post<object>("dnd.endDnd", new Args(), cancellationToken);
 
         /// <summary>
         /// Ends the current user's snooze mode immediately.
         /// </summary>
         /// <param name="cancellationToken"></param>
         public Task<DndResponse> EndSnooze(CancellationToken? cancellationToken = null) =>
-            _client.Get<DndResponse>("dnd.endSnooze", new Args(), cancellationToken);
+            _client.Post<DndResponse>("dnd.endSnooze", new Args(), cancellationToken);
 
         /// <summary>
         /// Provides information about the current user's Do Not Disturb settings.

--- a/SlackNet/WebApi/DndApi.cs
+++ b/SlackNet/WebApi/DndApi.cs
@@ -59,7 +59,7 @@ namespace SlackNet.WebApi
         /// </summary>
         /// <param name="cancellationToken"></param>
         public Task EndDnd(CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("dnd.endDnd", new Args(), cancellationToken);
+            _client.Post("dnd.endDnd", new Args(), cancellationToken);
 
         /// <summary>
         /// Ends the current user's snooze mode immediately.

--- a/SlackNet/WebApi/FileCommentsApi.cs
+++ b/SlackNet/WebApi/FileCommentsApi.cs
@@ -29,7 +29,7 @@ namespace SlackNet.WebApi
         /// <param name="commentId">The comment to delete.</param>
         /// <param name="cancellationToken"></param>
         public Task Delete(string fileId, string commentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("files.comments.delete", new Args
+            _client.Post("files.comments.delete", new Args
                 {
                     { "file", fileId },
                     { "id", commentId }

--- a/SlackNet/WebApi/FileCommentsApi.cs
+++ b/SlackNet/WebApi/FileCommentsApi.cs
@@ -29,7 +29,7 @@ namespace SlackNet.WebApi
         /// <param name="commentId">The comment to delete.</param>
         /// <param name="cancellationToken"></param>
         public Task Delete(string fileId, string commentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("files.comments.delete", new Args
+            _client.Post<object>("files.comments.delete", new Args
                 {
                     { "file", fileId },
                     { "id", commentId }

--- a/SlackNet/WebApi/FilesApi.cs
+++ b/SlackNet/WebApi/FilesApi.cs
@@ -164,7 +164,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">ID of file to delete.</param>
         /// <param name="cancellationToken"></param>
         public Task Delete(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("files.delete", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post("files.delete", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Returns information about a file in your team.

--- a/SlackNet/WebApi/FilesApi.cs
+++ b/SlackNet/WebApi/FilesApi.cs
@@ -164,7 +164,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">ID of file to delete.</param>
         /// <param name="cancellationToken"></param>
         public Task Delete(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("files.delete", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post<object>("files.delete", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Returns information about a file in your team.
@@ -219,7 +219,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to revoke</param>
         /// <param name="cancellationToken"></param>
         public Task<FileResponse> RevokePublicUrl(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get<FileResponse>("files.revokePublicURL", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post<FileResponse>("files.revokePublicURL", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Enables public/external sharing for a file.
@@ -227,7 +227,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to share.</param>
         /// <param name="cancellationToken"></param>
         public Task<FileAndCommentsResponse> SharedPublicUrl(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get<FileAndCommentsResponse>("files.sharedPublicURL", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post<FileAndCommentsResponse>("files.sharedPublicURL", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Allows you to create or upload an existing file.

--- a/SlackNet/WebApi/GroupsApi.cs
+++ b/SlackNet/WebApi/GroupsApi.cs
@@ -172,7 +172,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Private channel to archive.</param>
         /// <param name="cancellationToken"></param>
         public Task Archive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("groups.archive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("groups.archive", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Closes a private channel.
@@ -270,7 +270,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Kick(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("groups.kick", new Args
+            _client.Post("groups.kick", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -282,7 +282,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Private channel to leave.</param>
         /// <param name="cancellationToken"></param>
         public Task Leave(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("groups.leave", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("groups.leave", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a list of private channels in the team that the caller is in and archived groups that the caller was in. 
@@ -300,7 +300,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("groups.mark", new Args { { "channel", channelId }, { "ts", ts } }, cancellationToken);
+            _client.Post("groups.mark", new Args { { "channel", channelId }, { "ts", ts } }, cancellationToken);
 
         /// <summary>
         /// Opens a private channel.
@@ -309,7 +309,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Open(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("groups.open", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("groups.open", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Renames a private channel.
@@ -377,6 +377,6 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Private channel to unarchive.</param>
         /// <param name="cancellationToken"></param>
         public Task Unarchive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("groups.unarchive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("groups.unarchive", new Args { { "channel", channelId } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/GroupsApi.cs
+++ b/SlackNet/WebApi/GroupsApi.cs
@@ -172,7 +172,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Private channel to archive.</param>
         /// <param name="cancellationToken"></param>
         public Task Archive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("groups.archive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("groups.archive", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Closes a private channel.
@@ -189,7 +189,7 @@ namespace SlackNet.WebApi
         /// <param name="validate">Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Create(string name, bool validate = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<GroupResponse>("groups.create", new Args
+            (await _client.Post<GroupResponse>("groups.create", new Args
                 {
                     { "name", name },
                     { "validate", validate }
@@ -255,7 +255,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">User to invite.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Invite(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<GroupResponse>("groups.invite", new Args
+            (await _client.Post<GroupResponse>("groups.invite", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -270,7 +270,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Kick(string channelId, string userId, CancellationToken? cancellationToken = null) =>
-            _client.Get("groups.kick", new Args
+            _client.Post<object>("groups.kick", new Args
                 {
                     { "channel", channelId },
                     { "user", userId }
@@ -282,7 +282,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Private channel to leave.</param>
         /// <param name="cancellationToken"></param>
         public Task Leave(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("groups.leave", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("groups.leave", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a list of private channels in the team that the caller is in and archived groups that the caller was in. 
@@ -300,7 +300,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("groups.mark", new Args { { "channel", channelId }, { "ts", ts } }, cancellationToken);
+            _client.Post<object>("groups.mark", new Args { { "channel", channelId }, { "ts", ts } }, cancellationToken);
 
         /// <summary>
         /// Opens a private channel.
@@ -309,7 +309,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task Open(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("groups.open", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("groups.open", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Renames a private channel.
@@ -319,7 +319,7 @@ namespace SlackNet.WebApi
         /// <param name="validate">Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Rename(string channelId, string name, bool validate = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<GroupRenameResponse>("groups.rename", new Args
+            (await _client.Post<GroupRenameResponse>("groups.rename", new Args
                 {
                     { "channel", channelId },
                     { "name", name },
@@ -349,7 +349,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns>The group's new purpose.</returns>
         public async Task<string> SetPurpose(string channelId, string purpose, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<PurposeResponse>("groups.setPurpose", new Args
+            (await _client.Post<PurposeResponse>("groups.setPurpose", new Args
                 {
                     { "channel", channelId },
                     { "purpose", purpose }
@@ -364,7 +364,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         /// <returns>The private channel's new topic.</returns>
         public async Task<string> SetTopic(string channelId, string topic, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<TopicResponse>("groups.setTopic", new Args
+            (await _client.Post<TopicResponse>("groups.setTopic", new Args
                 {
                     { "channel", channelId },
                     { "topic", topic }
@@ -377,6 +377,6 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Private channel to unarchive.</param>
         /// <param name="cancellationToken"></param>
         public Task Unarchive(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("groups.unarchive", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("groups.unarchive", new Args { { "channel", channelId } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/ImApi.cs
+++ b/SlackNet/WebApi/ImApi.cs
@@ -80,7 +80,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Direct message channel to close.</param>
         /// <param name="cancellationToken"></param>
         public Task Close(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("im.close", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("im.close", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a portion of message events from the specified direct message channel.
@@ -129,7 +129,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("im.mark", new Args
+            _client.Post("im.mark", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts }

--- a/SlackNet/WebApi/ImApi.cs
+++ b/SlackNet/WebApi/ImApi.cs
@@ -80,7 +80,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Direct message channel to close.</param>
         /// <param name="cancellationToken"></param>
         public Task Close(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("im.close", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("im.close", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a portion of message events from the specified direct message channel.
@@ -129,7 +129,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("im.mark", new Args
+            _client.Post<object>("im.mark", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts }
@@ -142,7 +142,7 @@ namespace SlackNet.WebApi
         /// <param name="returnIm">Indicates you want the full IM channel definition in the response.</param>
         /// <param name="cancellationToken"></param>
         public Task<ImResponse> Open(string userId, bool returnIm = false, CancellationToken? cancellationToken = null) =>
-            _client.Get<ImResponse>("im.open", new Args
+            _client.Post<ImResponse>("im.open", new Args
                 {
                     { "user", userId },
                     { "return_im", returnIm }

--- a/SlackNet/WebApi/MpimApi.cs
+++ b/SlackNet/WebApi/MpimApi.cs
@@ -79,7 +79,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">MPIM to close.</param>
         /// <param name="cancellationToken"></param>
         public Task Close(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("mpim.close", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("mpim.close", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a portion of message events from the specified multiparty direct message channel.
@@ -128,7 +128,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("mpim.mark", new Args
+            _client.Post("mpim.mark", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts }

--- a/SlackNet/WebApi/MpimApi.cs
+++ b/SlackNet/WebApi/MpimApi.cs
@@ -79,7 +79,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">MPIM to close.</param>
         /// <param name="cancellationToken"></param>
         public Task Close(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("mpim.close", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("mpim.close", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Returns a portion of message events from the specified multiparty direct message channel.
@@ -128,7 +128,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the most recently seen message.</param>
         /// <param name="cancellationToken"></param>
         public Task Mark(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("mpim.mark", new Args
+            _client.Post<object>("mpim.mark", new Args
                 {
                     { "channel", channelId },
                     { "ts", ts }
@@ -140,7 +140,7 @@ namespace SlackNet.WebApi
         /// <param name="userIds">List of users. The ordering of the users is preserved whenever a MPIM group is returned.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Channel> Open(IEnumerable<string> userIds, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<GroupResponse>("mpim.open", new Args { { "users", userIds } }, cancellationToken).ConfigureAwait(false)).Group;
+            (await _client.Post<GroupResponse>("mpim.open", new Args { { "users", userIds } }, cancellationToken).ConfigureAwait(false)).Group;
 
         /// <summary>
         /// Returns an entire thread (a message plus all the messages in reply to it).

--- a/SlackNet/WebApi/PinsApi.cs
+++ b/SlackNet/WebApi/PinsApi.cs
@@ -80,7 +80,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to pin.</param>
         /// <param name="cancellationToken"></param>
         public Task AddFile(string channelId, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("pins.add", new Args
+            _client.Post("pins.add", new Args
                 {
                     { "channel", channelId },
                     { "file", fileId }
@@ -93,7 +93,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to pin.</param>
         /// <param name="cancellationToken"></param>
         public Task AddFileComment(string channelId, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("pins.add", new Args
+            _client.Post("pins.add", new Args
                 {
                     { "channel", channelId },
                     { "file_comment", fileCommentId },
@@ -106,7 +106,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to pin.</param>
         /// <param name="cancellationToken"></param>
         public Task AddMessage(string channelId, string ts = null, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("pins.add", new Args
+            _client.Post("pins.add", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }
@@ -127,7 +127,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to un-pin.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFile(string channelId, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("pins.remove", new Args
+            _client.Post("pins.remove", new Args
                 {
                     { "channel", channelId },
                     { "file", fileId }
@@ -140,7 +140,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to un-pin.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFileComment(string channelId, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("pins.remove", new Args
+            _client.Post("pins.remove", new Args
                 {
                     { "channel", channelId },
                     { "file_comment", fileCommentId }
@@ -153,7 +153,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to un-pin.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveMessage(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("pins.remove", new Args
+            _client.Post("pins.remove", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }

--- a/SlackNet/WebApi/PinsApi.cs
+++ b/SlackNet/WebApi/PinsApi.cs
@@ -80,7 +80,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to pin.</param>
         /// <param name="cancellationToken"></param>
         public Task AddFile(string channelId, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("pins.add", new Args
+            _client.Post<object>("pins.add", new Args
                 {
                     { "channel", channelId },
                     { "file", fileId }
@@ -93,7 +93,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to pin.</param>
         /// <param name="cancellationToken"></param>
         public Task AddFileComment(string channelId, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("pins.add", new Args
+            _client.Post<object>("pins.add", new Args
                 {
                     { "channel", channelId },
                     { "file_comment", fileCommentId },
@@ -106,7 +106,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to pin.</param>
         /// <param name="cancellationToken"></param>
         public Task AddMessage(string channelId, string ts = null, CancellationToken? cancellationToken = null) =>
-            _client.Get("pins.add", new Args
+            _client.Post<object>("pins.add", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }
@@ -127,7 +127,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to un-pin.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFile(string channelId, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("pins.remove", new Args
+            _client.Post<object>("pins.remove", new Args
                 {
                     { "channel", channelId },
                     { "file", fileId }
@@ -140,7 +140,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to un-pin.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFileComment(string channelId, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("pins.remove", new Args
+            _client.Post<object>("pins.remove", new Args
                 {
                     { "channel", channelId },
                     { "file_comment", fileCommentId }
@@ -153,7 +153,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to un-pin.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveMessage(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("pins.remove", new Args
+            _client.Post<object>("pins.remove", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }

--- a/SlackNet/WebApi/ReactionsApi.cs
+++ b/SlackNet/WebApi/ReactionsApi.cs
@@ -105,7 +105,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to add reaction to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFile(string name, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reactions.add", new Args
+            _client.Post("reactions.add", new Args
                 {
                     { "name", name },
                     { "file", fileId }
@@ -118,7 +118,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to add reaction to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFileComment(string name, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reactions.add", new Args
+            _client.Post("reactions.add", new Args
                 {
                     { "name", name },
                     { "file_comment", fileCommentId }
@@ -132,7 +132,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to add reaction to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToMessage(string name, string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reactions.add", new Args
+            _client.Post("reactions.add", new Args
                 {
                     { "name", name },
                     { "channel", channelId },
@@ -207,7 +207,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to remove reaction from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFile(string name, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reactions.remove", new Args
+            _client.Post("reactions.remove", new Args
                 {
                     { "name", name },
                     { "file", fileId }
@@ -220,7 +220,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to remove reaction from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFileComment(string name, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reactions.remove", new Args
+            _client.Post("reactions.remove", new Args
                 {
                     { "name", name },
                     { "file_comment", fileCommentId }
@@ -234,7 +234,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to remove reaction from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromMessage(string name, string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reactions.remove", new Args
+            _client.Post("reactions.remove", new Args
                 {
                     { "name", name },
                     { "channel", channelId },

--- a/SlackNet/WebApi/ReactionsApi.cs
+++ b/SlackNet/WebApi/ReactionsApi.cs
@@ -105,7 +105,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to add reaction to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFile(string name, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("reactions.add", new Args
+            _client.Post<object>("reactions.add", new Args
                 {
                     { "name", name },
                     { "file", fileId }
@@ -118,7 +118,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to add reaction to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFileComment(string name, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("reactions.add", new Args
+            _client.Post<object>("reactions.add", new Args
                 {
                     { "name", name },
                     { "file_comment", fileCommentId }
@@ -132,7 +132,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to add reaction to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToMessage(string name, string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("reactions.add", new Args
+            _client.Post<object>("reactions.add", new Args
                 {
                     { "name", name },
                     { "channel", channelId },
@@ -207,7 +207,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to remove reaction from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFile(string name, string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("reactions.remove", new Args
+            _client.Post<object>("reactions.remove", new Args
                 {
                     { "name", name },
                     { "file", fileId }
@@ -220,7 +220,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to remove reaction from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFileComment(string name, string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("reactions.remove", new Args
+            _client.Post<object>("reactions.remove", new Args
                 {
                     { "name", name },
                     { "file_comment", fileCommentId }
@@ -234,7 +234,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to remove reaction from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromMessage(string name, string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("reactions.remove", new Args
+            _client.Post<object>("reactions.remove", new Args
                 {
                     { "name", name },
                     { "channel", channelId },

--- a/SlackNet/WebApi/RemindersApi.cs
+++ b/SlackNet/WebApi/RemindersApi.cs
@@ -130,7 +130,7 @@ namespace SlackNet.WebApi
         /// <param name="reminderId">The ID of the reminder to be marked as complete.</param>
         /// <param name="cancellationToken"></param>
         public Task Complete(string reminderId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reminders.complete", new Args { { "reminder", reminderId } }, cancellationToken);
+            _client.Post("reminders.complete", new Args { { "reminder", reminderId } }, cancellationToken);
 
         /// <summary>
         /// Deletes a reminder.
@@ -138,7 +138,7 @@ namespace SlackNet.WebApi
         /// <param name="reminderId">The ID of the reminder.</param>
         /// <param name="cancellationToken"></param>
         public Task Delete(string reminderId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("reminders.delete", new Args { { "reminder", reminderId } }, cancellationToken);
+            _client.Post("reminders.delete", new Args { { "reminder", reminderId } }, cancellationToken);
 
         /// <summary>
         /// Returns information about a reminder.

--- a/SlackNet/WebApi/RemindersApi.cs
+++ b/SlackNet/WebApi/RemindersApi.cs
@@ -80,7 +80,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">The user who will receive the reminder. If no user is specified, the reminder will go to user who created it.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Reminder> Add(string text, DateTime time, string userId = null, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ReminderResponse>("reminders.add", new Args
+            (await _client.Post<ReminderResponse>("reminders.add", new Args
                 {
                     { "text", text },
                     { "time", time.ToTimestamp() },
@@ -96,7 +96,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">The user who will receive the reminder. If no user is specified, the reminder will go to user who created it.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Reminder> Add(string text, TimeSpan time, string userId = null, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ReminderResponse>("reminders.add", new Args
+            (await _client.Post<ReminderResponse>("reminders.add", new Args
                 {
                     { "text", text },
                     { "time", time.ToOffset(TimeSpan.FromHours(24)) },
@@ -116,7 +116,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">The user who will receive the reminder. If no user is specified, the reminder will go to user who created it.</param>
         /// <param name="cancellationToken"></param>
         public async Task<Reminder> Add(string text, string time, string userId = null, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<ReminderResponse>("reminders.add", new Args
+            (await _client.Post<ReminderResponse>("reminders.add", new Args
                 {
                     { "text", text },
                     { "time", time },
@@ -130,7 +130,7 @@ namespace SlackNet.WebApi
         /// <param name="reminderId">The ID of the reminder to be marked as complete.</param>
         /// <param name="cancellationToken"></param>
         public Task Complete(string reminderId, CancellationToken? cancellationToken = null) =>
-            _client.Get("reminders.complete", new Args { { "reminder", reminderId } }, cancellationToken);
+            _client.Post<object>("reminders.complete", new Args { { "reminder", reminderId } }, cancellationToken);
 
         /// <summary>
         /// Deletes a reminder.
@@ -138,7 +138,7 @@ namespace SlackNet.WebApi
         /// <param name="reminderId">The ID of the reminder.</param>
         /// <param name="cancellationToken"></param>
         public Task Delete(string reminderId, CancellationToken? cancellationToken = null) =>
-            _client.Get("reminders.delete", new Args { { "reminder", reminderId } }, cancellationToken);
+            _client.Post<object>("reminders.delete", new Args { { "reminder", reminderId } }, cancellationToken);
 
         /// <summary>
         /// Returns information about a reminder.

--- a/SlackNet/WebApi/ScheduledMessagesApi.cs
+++ b/SlackNet/WebApi/ScheduledMessagesApi.cs
@@ -54,7 +54,7 @@ namespace SlackNet.WebApi
             string cursor = null,
             CancellationToken? cancellationToken = null
         ) =>
-            _client.Get<ScheduledMessageListResponse>("chat.scheduledMessages.list", new Args
+            _client.Post<ScheduledMessageListResponse>("chat.scheduledMessages.list", new Args
                 {
                     { "channel", channelId },
                     { "latest", latestTs },

--- a/SlackNet/WebApi/StarsApi.cs
+++ b/SlackNet/WebApi/StarsApi.cs
@@ -85,7 +85,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFile(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.add", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post<object>("stars.add", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Adds a star to a file comment.
@@ -93,7 +93,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFileComment(string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.add", new Args { { "file_comment", fileCommentId } }, cancellationToken);
+            _client.Post<object>("stars.add", new Args { { "file_comment", fileCommentId } }, cancellationToken);
 
         /// <summary>
         /// Adds a star to a channel.
@@ -101,7 +101,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Channel, private group, or DM to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToChannel(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.add", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("stars.add", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Adds a star to a message.
@@ -110,7 +110,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToMessage(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.add", new Args
+            _client.Post<object>("stars.add", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }
@@ -136,7 +136,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFile(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.remove", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post<object>("stars.remove", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Removes a star from a file comment.
@@ -144,7 +144,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFileComment(string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.remove", new Args { { "file_comment", fileCommentId } }, cancellationToken);
+            _client.Post<object>("stars.remove", new Args { { "file_comment", fileCommentId } }, cancellationToken);
 
         /// <summary>
         /// Removes a star from a channel.
@@ -152,7 +152,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Channel, private group, or DM to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromChannel(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.remove", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post<object>("stars.remove", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Removes a star from a message.
@@ -161,7 +161,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromMessage(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Get("stars.remove", new Args
+            _client.Post<object>("stars.remove", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }

--- a/SlackNet/WebApi/StarsApi.cs
+++ b/SlackNet/WebApi/StarsApi.cs
@@ -85,7 +85,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFile(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.add", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post("stars.add", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Adds a star to a file comment.
@@ -93,7 +93,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToFileComment(string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.add", new Args { { "file_comment", fileCommentId } }, cancellationToken);
+            _client.Post("stars.add", new Args { { "file_comment", fileCommentId } }, cancellationToken);
 
         /// <summary>
         /// Adds a star to a channel.
@@ -101,7 +101,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Channel, private group, or DM to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToChannel(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.add", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("stars.add", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Adds a star to a message.
@@ -110,7 +110,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to add star to.</param>
         /// <param name="cancellationToken"></param>
         public Task AddToMessage(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.add", new Args
+            _client.Post("stars.add", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }
@@ -136,7 +136,7 @@ namespace SlackNet.WebApi
         /// <param name="fileId">File to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFile(string fileId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.remove", new Args { { "file", fileId } }, cancellationToken);
+            _client.Post("stars.remove", new Args { { "file", fileId } }, cancellationToken);
 
         /// <summary>
         /// Removes a star from a file comment.
@@ -144,7 +144,7 @@ namespace SlackNet.WebApi
         /// <param name="fileCommentId">File comment to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromFileComment(string fileCommentId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.remove", new Args { { "file_comment", fileCommentId } }, cancellationToken);
+            _client.Post("stars.remove", new Args { { "file_comment", fileCommentId } }, cancellationToken);
 
         /// <summary>
         /// Removes a star from a channel.
@@ -152,7 +152,7 @@ namespace SlackNet.WebApi
         /// <param name="channelId">Channel, private group, or DM to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromChannel(string channelId, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.remove", new Args { { "channel", channelId } }, cancellationToken);
+            _client.Post("stars.remove", new Args { { "channel", channelId } }, cancellationToken);
 
         /// <summary>
         /// Removes a star from a message.
@@ -161,7 +161,7 @@ namespace SlackNet.WebApi
         /// <param name="ts">Timestamp of the message to remove star from.</param>
         /// <param name="cancellationToken"></param>
         public Task RemoveFromMessage(string channelId, string ts, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("stars.remove", new Args
+            _client.Post("stars.remove", new Args
                 {
                     { "channel", channelId },
                     { "timestamp", ts }

--- a/SlackNet/WebApi/UserGroupUsersApi.cs
+++ b/SlackNet/WebApi/UserGroupUsersApi.cs
@@ -54,7 +54,7 @@ namespace SlackNet.WebApi
         /// <param name="includeCount">Include the number of users in the User Group.</param>
         /// <param name="cancellationToken"></param>
         public async Task<UserGroup> Update(string userGroupId, IEnumerable<string> userIds, bool includeCount = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<UserGroupResponse>("usergroups.users.update", new Args
+            (await _client.Post<UserGroupResponse>("usergroups.users.update", new Args
                 {
                     { "usergroup", userGroupId },
                     { "users", userIds },

--- a/SlackNet/WebApi/UserGroupsApi.cs
+++ b/SlackNet/WebApi/UserGroupsApi.cs
@@ -93,7 +93,7 @@ namespace SlackNet.WebApi
             bool includeCount = false,
             CancellationToken? cancellationToken = null
         ) =>
-            (await _client.Get<UserGroupResponse>("usergroups.create", new Args
+            (await _client.Post<UserGroupResponse>("usergroups.create", new Args
                 {
                     { "name", name },
                     { "channels", channelIds },
@@ -110,7 +110,7 @@ namespace SlackNet.WebApi
         /// <param name="includeCount">Include the number of users in the User Group.</param>
         /// <param name="cancellationToken"></param>
         public async Task<UserGroup> Disable(string userGroupId, bool includeCount = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<UserGroupResponse>("usergroups.disable", new Args
+            (await _client.Post<UserGroupResponse>("usergroups.disable", new Args
                 {
                     { "usergroup", userGroupId },
                     { "include_count", includeCount }
@@ -124,7 +124,7 @@ namespace SlackNet.WebApi
         /// <param name="includeCount">Include the number of users in the User Group.</param>
         /// <param name="cancellationToken"></param>
         public async Task<UserGroup> Enable(string userGroupId, bool includeCount = false, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<UserGroupResponse>("usergroups.enable", new Args
+            (await _client.Post<UserGroupResponse>("usergroups.enable", new Args
                 {
                     { "usergroup", userGroupId },
                     { "include_count", includeCount }
@@ -166,7 +166,7 @@ namespace SlackNet.WebApi
             string name = null,
             CancellationToken? cancellationToken = null
         ) =>
-            (await _client.Get<UserGroupResponse>("usergroups.create", new Args
+            (await _client.Post<UserGroupResponse>("usergroups.update", new Args
                 {
                     { "usergroup", userGroupId },
                     { "channels", channelIds },

--- a/SlackNet/WebApi/UserProfileApi.cs
+++ b/SlackNet/WebApi/UserProfileApi.cs
@@ -59,7 +59,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">ID of user to change (defaults to authed user). This argument may only be specified by team admins on paid teams.</param>
         /// <param name="cancellationToken"></param>
         public async Task<UserProfile> Set(string name, string value, string userId = null, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<UserProfileResponse>("users.profile.set", new Args
+            (await _client.Post<UserProfileResponse>("users.profile.set", new Args
                 {
                     { "name", name },
                     { "value", value },
@@ -74,7 +74,7 @@ namespace SlackNet.WebApi
         /// <param name="userId">ID of user to change (defaults to authed user). This argument may only be specified by team admins on paid teams.</param>
         /// <param name="cancellationToken"></param>
         public async Task<UserProfile> Set(UserProfile profile, string userId = null, CancellationToken? cancellationToken = null) =>
-            (await _client.Get<UserProfileResponse>("users.profile.set", new Args
+            (await _client.Post<UserProfileResponse>("users.profile.set", new Args
                 {
                     { "profile", profile },
                     { "user", userId }

--- a/SlackNet/WebApi/UsersApi.cs
+++ b/SlackNet/WebApi/UsersApi.cs
@@ -269,6 +269,6 @@ namespace SlackNet.WebApi
         /// <param name="presence">User's presence.</param>
         /// <param name="cancellationToken"></param>
         public Task SetPresence(Presence presence, CancellationToken? cancellationToken = null) =>
-            _client.Get("users.setPresence", new Args { { "presence", presence } }, cancellationToken);
+            _client.Post<object>("users.setPresence", new Args { { "presence", presence } }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/UsersApi.cs
+++ b/SlackNet/WebApi/UsersApi.cs
@@ -269,6 +269,6 @@ namespace SlackNet.WebApi
         /// <param name="presence">User's presence.</param>
         /// <param name="cancellationToken"></param>
         public Task SetPresence(Presence presence, CancellationToken? cancellationToken = null) =>
-            _client.Post<object>("users.setPresence", new Args { { "presence", presence } }, cancellationToken);
+            _client.Post("users.setPresence", new Args { { "presence", presence } }, cancellationToken);
     }
 }


### PR DESCRIPTION
Slack has preferred HTTP methods described in their API Docs. This will make the WebApi part comply with those.  

Since this a quite large change some testing might be needed, I've tested a some of the actions without problems. This also closes #16. 