### PR TITLE
Adding Ephemeral property to BotMessage

### DIFF
--- a/SlackNet.Bot/BotMessage.cs
+++ b/SlackNet.Bot/BotMessage.cs
@@ -50,5 +50,10 @@ namespace SlackNet.Bot
         /// Set to True to reply in a new thread if not already in one.
         /// </summary>
         public bool CreateThread { get; set; }
+        /// <summary>
+        /// Set to True to make this an ephemeral message, which is visible only to the assigned user in a specific public channel, private channel, or private conversation.
+        /// Note that not all message properties are supported by ephemeral messages.
+        /// </summary>
+        public bool Ephemeral { get; set; }
     }
 }


### PR DESCRIPTION
Allows sending ephemeral replies with bot. @eFloh please let me know if this is what you had in mind.

I avoided changing `SlackMessage` - I didn't really want to add a second boolean parameter to the `ReplyWith` methods (I probably shouldn't have added the first one TBH). I'm open to alternatives though.

At the moment it only supports _replying_ with ephemeral messages, not sending them out of the blue. We could probably add a separate property for the user if necessary.