### PR TITLE
Implementing request signature verification

### DIFF
--- a/SlackNet.AspNetCore/SlackEndpointConfiguration.cs
+++ b/SlackNet.AspNetCore/SlackEndpointConfiguration.cs
@@ -14,6 +14,12 @@
             return this;
         }
 
+        public SlackEndpointConfiguration UseSigningSecret(string signingSecret)
+        {
+            SigningSecret = signingSecret;
+            return this;
+        }
+
         /// <summary>
         /// Path to receive Slack requests on. Defaults to "slack".
         /// Configures the following routes:
@@ -28,5 +34,11 @@
         /// You'll find this value in the "App Credentials" section of your app's application management interface.
         /// </summary>
         public string VerificationToken { get; private set; }
+        
+        /// <summary>
+        /// Use this signing secret to verify that requests are coming from Slack.
+        /// You'll find this value in the "App Credentials" section of your app's application management interface.
+        /// </summary>
+        public string SigningSecret { get; private set; }
     }
 }

--- a/SlackNet.AspNetCore/SlackEventsMiddleware.cs
+++ b/SlackNet.AspNetCore/SlackEventsMiddleware.cs
@@ -224,7 +224,7 @@ namespace SlackNet.AspNetCore
             }
         }
         
-        private bool IsValidToken(string token) => !string.IsNullOrEmpty(_configuration.VerificationToken) || token == _configuration.VerificationToken;
+        private bool IsValidToken(string token) => string.IsNullOrEmpty(_configuration.VerificationToken) || token == _configuration.VerificationToken;
 
         private string Serialize(object value) => JsonConvert.SerializeObject(value, _jsonSettings.SerializerSettings);
 


### PR DESCRIPTION
It's now possible to verify that requests are coming from Slack using their HMAC based signature, this is mentioned in #10 which would also be closed by this.
This will prefer signature verification if possible and fallback on token based verification.  

So there will be **no** breaking changes for users that does not wish to use signature verification.

Added a new configuration element as follows.
```csharp
app.UseSlackNet(c =>
{
    c.VerifyWith(Configuration["Slack:VerificationToken"]);
    c.UseSigningSecret(Configuration["Slack:VerificationSignature"]);
});
```

I've also made changes to the function `IsValidToken()`, this method would return `true` if `_configuration.VerificationToken` was null or empty. I think this was an errornous behaviour?