### PR TITLE
Updated to .NET Standard 2.0.

### DIFF
--- a/SlackNet.Bot/SlackNet.Bot.csproj
+++ b/SlackNet.Bot/SlackNet.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Simon Oxtoby</Authors>
     <Description>Easy-to-use API for writing Slack bots</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/SlackNet.BotExample/SlackNet.BotExample.csproj
+++ b/SlackNet.BotExample/SlackNet.BotExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/SlackNet.EventsExample/BlockColorSelector.cs
+++ b/SlackNet.EventsExample/BlockColorSelector.cs
@@ -27,7 +27,8 @@ namespace SlackNet.EventsExample
             }).ConfigureAwait(false);
         }
 
-        public async Task<BlockOptionsResponse> GetOptions(BlockOptionsRequest request) => new BlockOptionsResponse { Options = GetBlockOptions(request.Value) };
+        public Task<BlockOptionsResponse> GetOptions(BlockOptionsRequest request) => 
+            Task.FromResult(new BlockOptionsResponse { Options = GetBlockOptions(request.Value) });
 
         private static List<Blocks.Option> GetBlockOptions(string search) =>
             FindColors(search)

--- a/SlackNet.EventsExample/ColorSelector.cs
+++ b/SlackNet.EventsExample/ColorSelector.cs
@@ -11,7 +11,7 @@ namespace SlackNet.EventsExample
     {
         public static readonly string ActionName = "color_select";
 
-        public async Task<MessageResponse> Handle(InteractiveMessage message)
+        public Task<MessageResponse> Handle(InteractiveMessage message)
         {
             var menu = (Menu)message.Action;
             message.OriginalAttachment.Color = menu.SelectedValue;
@@ -22,14 +22,15 @@ namespace SlackNet.EventsExample
                     ?? new Option { Text = menu.SelectedValue, Value = menu.SelectedValue }
                 };
 
-            return new MessageResponse
+            return Task.FromResult(new MessageResponse
                 {
                     ReplaceOriginal = true,
                     Message = message.OriginalMessage
-                };
+                });
         }
 
-        public async Task<OptionsResponse> GetOptions(OptionsRequest request) => new OptionsResponse { Options = GetOptions(request.Value) };
+        public Task<OptionsResponse> GetOptions(OptionsRequest request) => 
+            Task.FromResult(new OptionsResponse { Options = GetOptions(request.Value) });
 
         private static List<Option> GetOptions(string search) =>
             FindColors(search)

--- a/SlackNet.EventsExample/LegacyCounter.cs
+++ b/SlackNet.EventsExample/LegacyCounter.cs
@@ -13,7 +13,7 @@ namespace SlackNet.EventsExample
 
         private static readonly Regex _counterPattern = new Regex("Counter: (\\d+)");
 
-        public async Task<MessageResponse> Handle(InteractiveMessage message)
+        public Task<MessageResponse> Handle(InteractiveMessage message)
         {
             var counterText = _counterPattern.Match(message.OriginalAttachment.Text);
             if (counterText.Success)
@@ -22,14 +22,14 @@ namespace SlackNet.EventsExample
                 var increment = int.Parse(message.Action.Value);
                 message.OriginalAttachment.Text = $"Counter: {count + increment}";
                 message.OriginalAttachment.Actions = Actions;
-                return new MessageResponse
+                return Task.FromResult(new MessageResponse
                     {
                         ReplaceOriginal = true,
                         Message = message.OriginalMessage
-                    };
+                    });
             }
 
-            return null;
+            return Task.FromResult<MessageResponse>(null);
         }
 
         public static IList<ActionElement> Actions => new List<ActionElement>

--- a/SlackNet.Example/SlackNet.Example.csproj
+++ b/SlackNet.Example/SlackNet.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/SlackNet.Tests/SlackNet.Tests.csproj
+++ b/SlackNet.Tests/SlackNet.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="EasyAssertions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.3.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/SlackNet/SlackNet.csproj
+++ b/SlackNet/SlackNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Simon Oxtoby</Authors>
     <Description>A comprehensive Slack API client for .NET</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.3.2" />
     <PackageReference Include="WebSocket4Net" Version="0.15.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Addresses #31 

Updates minimum version to .NET Standard 2.0.

Also addresses four build warnings regarding using `async` without at least one `await` in methods. 