### PR TITLE
Fixes for new bot tokens, and new command handler for /command sub-command handling.

### DIFF
--- a/SlackNet.Bot/SlackBot.cs
+++ b/SlackNet.Bot/SlackBot.cs
@@ -459,7 +459,7 @@ namespace SlackNet.Bot
                     LinkNames = message.LinkNames,
                     UnfurlLinks = message.UnfurlLinks,
                     UnfurlMedia = message.UnfurlMedia,
-                    AsUser = true
+                    //AsUser = true
                 }, message.CancellationToken).ConfigureAwait(false);
 
         private async Task<bool> ReplyingInDifferentHub(BotMessage message)

--- a/SlackNet/Interaction/MessageResponseWrapper.cs
+++ b/SlackNet/Interaction/MessageResponseWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using SlackNet.Blocks;
 using SlackNet.WebApi;
@@ -18,6 +19,7 @@ namespace SlackNet.Interaction
         public bool UnfurlLinks => _response.Message?.UnfurlLinks ?? default;
         public bool UnfurlMedia => _response.Message?.UnfurlMedia ?? default;
         public string Username => _response.Message?.Username;
+        [Obsolete("as_user: This argument may not be used with newer bot tokens.")]
         public bool? AsUser => _response.Message?.AsUser;
         public string IconUrl => _response.Message?.IconUrl;
         public string IconEmoji => _response.Message?.IconEmoji;

--- a/SlackNet/Interaction/SlashCompositeCommandHandler.cs
+++ b/SlackNet/Interaction/SlashCompositeCommandHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+
+namespace SlackNet.Interaction
+{
+    public class SlashCompositeCommandHandler : ISlashCommandHandler
+    {
+        readonly ISlackSlashCommands _slackSlashCommands;
+
+        public SlashCompositeCommandHandler(ISlackSlashCommands slackSlashCommands) => _slackSlashCommands = slackSlashCommands;
+
+        public async Task<SlashCommandResponse> Handle(SlashCommand command) => await _slackSlashCommands.Handle(NextCommand(command)).ConfigureAwait(false);
+
+        protected virtual SlashCommand NextCommand(SlashCommand command)
+        {
+            var text = command.Text;
+            var idx = text.IndexOf(' ');
+            if (idx == -1)
+            {
+                command.Command += $" {text}";
+                command.Text = null;
+                return command;
+            }
+            command.Command += $" {text.Substring(0, idx)}";
+            command.Text = text.Substring(idx + 1);
+            return command;
+        }
+    }
+}

--- a/SlackNet/SlackApiClient.cs
+++ b/SlackNet/SlackApiClient.cs
@@ -103,7 +103,7 @@ namespace SlackNet
         /// <param name="responseUrl">A temporary webhook that can be used to send messages in response to interactions.</param>
         /// <param name="message">The message to respond with.</param>
         /// <param name="cancellationToken"></param>
-        Task Respond(string responseUrl, IReadOnlyMessage message, CancellationToken? cancellationToken);
+        Task Respond(string responseUrl, IReadOnlyMessage message, CancellationToken? cancellationToken = null);
     }
 
     public class SlackApiClient : ISlackApiClient
@@ -232,7 +232,7 @@ namespace SlackNet
         /// <param name="responseUrl">A temporary webhook that can be used to send messages in response to interactions.</param>
         /// <param name="message">The message to respond with.</param>
         /// <param name="cancellationToken"></param>
-        public Task Respond(string responseUrl, IReadOnlyMessage message, CancellationToken? cancellationToken) =>
+        public Task Respond(string responseUrl, IReadOnlyMessage message, CancellationToken? cancellationToken = null) =>
             Post<object>(responseUrl, message, cancellationToken);
 
         private async Task<T> Post<T>(string requestUri, object body, CancellationToken? cancellationToken) where T : class

--- a/SlackNet/SlackApiClient.cs
+++ b/SlackNet/SlackApiClient.cs
@@ -242,7 +242,7 @@ namespace SlackNet
             requestMessage.Content = new StringContent(JsonConvert.SerializeObject(body, _jsonSettings.SerializerSettings), Encoding.UTF8, "application/json");
 
             var response = await _http.Execute<WebApiResponse>(requestMessage, cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
-            return Deserialize<T>(response);
+            return response != null ? Deserialize<T>(response) : null;
         }
 
         private string Url(string apiMethod) =>

--- a/SlackNet/WebApi/ChatApi.cs
+++ b/SlackNet/WebApi/ChatApi.cs
@@ -159,7 +159,7 @@ namespace SlackNet.WebApi
             args["unfurl_links"] = message.UnfurlLinks;
             args["unfurl_media"] = message.UnfurlMedia;
             args["username"] = message.Username;
-            args["as_user"] = message.AsUser;
+            //args["as_user"] = message.AsUser;
             args["icon_url"] = message.IconUrl;
             args["icon_emoji"] = message.IconEmoji;
             args["thread_ts"] = message.ThreadTs;
@@ -179,7 +179,7 @@ namespace SlackNet.WebApi
                         { "channel", message.Channel },
                         { "text", message.Text },
                         { "user", userId },
-                        { "as_user", message.AsUser },
+                        //{ "as_user", message.AsUser },
                         { "attachments", message.Attachments },
                         { "blocks", message.Blocks },
                         { "link_names", message.LinkNames },

--- a/SlackNet/WebApi/Message.cs
+++ b/SlackNet/WebApi/Message.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SlackNet.Blocks;
 using SlackNet.Events;
 
@@ -54,6 +55,7 @@ namespace SlackNet.WebApi
         /// <summary>
         /// Pass True to post the message as the authed user, instead of as a bot.
         /// </summary>
+        [Obsolete("as_user: This argument may not be used with newer bot tokens.")]
         bool? AsUser { get; }
 
         /// <summary>
@@ -121,6 +123,7 @@ namespace SlackNet.WebApi
         /// <summary>
         /// Pass True to post the message as the authed user, instead of as a bot.
         /// </summary>
+        [Obsolete("as_user: This argument may not be used with newer bot tokens.")]
         public bool? AsUser { get; set; }
         /// <summary>
         /// URL to an image to use as the icon for this message. Must be used in conjunction with <see cref="AsUser"/> set to False, otherwise ignored.


### PR DESCRIPTION

Obsolete - as_user: This argument may not be used with newer bot tokens.
Added SlashCompositeCommandHandler - for multi-level command handling.
Handle deserialize error when result is "ok"

Checks fail, not sure how to increase build.