### PR TITLE
[BUGFIX] Fix serialization of conversation types

### DIFF
--- a/SlackNet/WebApi/ConversationType.cs
+++ b/SlackNet/WebApi/ConversationType.cs
@@ -1,4 +1,6 @@
-﻿namespace SlackNet.WebApi
+﻿using System.Linq;
+
+namespace SlackNet.WebApi
 {
     public enum ConversationType
     {
@@ -6,5 +8,14 @@
         PrivateChannel,
         Mpim,
         Im
+    }
+
+    public static class ConversationTypeExtensions
+    {
+        public static string ToSnakeCase(this ConversationType type) =>
+            string.Concat(type.ToString()
+                    .Select((x, i) => i > 0 && char.IsUpper(x) ? $"_{x}" : x.ToString()))
+                .ToLowerInvariant();
+
     }
 }

--- a/SlackNet/WebApi/ConversationsApi.cs
+++ b/SlackNet/WebApi/ConversationsApi.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Args = System.Collections.Generic.Dictionary<string, object>;
@@ -335,7 +336,7 @@ namespace SlackNet.WebApi
                     { "cursor", cursor },
                     { "exclude_archived", excludeArchived },
                     { "limit", limit },
-                    { "types", types }
+                    { "types", types?.Select(t => t.ToSnakeCase()) }
                 }, cancellationToken);
 
         /// <summary>

--- a/SlackNet/WebApi/UsersApi.cs
+++ b/SlackNet/WebApi/UsersApi.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -138,7 +139,7 @@ namespace SlackNet.WebApi
                     { "cursor", cursor },
                     { "exclude_archived", excludeArchived },
                     { "limit", limit },
-                    { "types", types },
+                    { "types", types?.Select(t => t.ToSnakeCase()) },
                     { "user", userId }
                 }, cancellationToken);
 


### PR DESCRIPTION
When trying to get conversations Slack currently responds with `invalid_types` exception due to incorrect serialization. 