### PR TITLE
[BUGFIX] Initial date and behaviour when date is null

### DIFF
--- a/SlackNet/Blocks/DatePicker.cs
+++ b/SlackNet/Blocks/DatePicker.cs
@@ -25,12 +25,12 @@ namespace SlackNet.Blocks
     [SlackType("datepicker")]
     public class DatePickerAction : BlockAction
     {
-        public DateTime SelectedDate { get; set; }
+        public DateTime? SelectedDate { get; set; }
     }
 
     [SlackType("datepicker")]
     public class DatePickerValue : ElementValue
     {
-        public DateTime SelectedDate { get; set; }
+        public DateTime? SelectedDate { get; set; }
     }
 }

--- a/SlackNet/Blocks/DatePicker.cs
+++ b/SlackNet/Blocks/DatePicker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace SlackNet.Blocks
 {
@@ -19,6 +20,7 @@ namespace SlackNet.Blocks
         /// <summary>
         /// The initial date that is selected when the element is loaded.
         /// </summary>
+        [JsonConverter(typeof(DateFormatConverter), "yyyy-MM-dd")]
         public DateTime? InitialDate { get; set; }
     }
 

--- a/SlackNet/DateFormatConverter.cs
+++ b/SlackNet/DateFormatConverter.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json.Converters;
+
+namespace SlackNet
+{
+    public class DateFormatConverter : IsoDateTimeConverter
+    {
+        public DateFormatConverter(string format)
+        {
+            DateTimeFormat = format;
+        }
+    }
+}


### PR DESCRIPTION
Since `SelectedDate` types were not nullable, they were defaulted to `January 1, 0001 00:00:00` when not set. 

`InitialDate` wasn't set properly because of its format.