### PR TITLE
[BUGFIX] Make SlackTypeConverter thread safe

### DIFF
--- a/SlackNet/Serialization/SlackTypeConverter.cs
+++ b/SlackNet/Serialization/SlackTypeConverter.cs
@@ -116,8 +116,9 @@ namespace SlackNet
             {
                 return serializer.Deserialize(reader, objectType);
             }
-            catch
-            {
+            catch (Exception ex)
+            { 
+                Console.Write($"Couldn't deserialize, fallback to default value. " + ex.Source);
                 return DefaultValue(objectType);
             }
             finally

--- a/SlackNet/Serialization/SlackTypeConverter.cs
+++ b/SlackNet/Serialization/SlackTypeConverter.cs
@@ -56,14 +56,12 @@ namespace SlackNet
             while (reader.Read() && reader.TokenType != JsonToken.EndArray)
                 list.Add(ReadJson(reader, elementType, serializer));
 
-            if (targetType.IsArray)
-            {
-                var array = Array.CreateInstance(targetType.GetElementType(), list.Count);
-                list.CopyTo(array, 0);
-                list = array;
-            }
+            if (!targetType.IsArray) return list;
+            
+            var array = Array.CreateInstance(targetType.GetElementType(), list.Count);
+            list.CopyTo(array, 0);
 
-            return list;
+            return array;
         }
 
         private static IList CreateCompatibleList(Type targetContainerType, Type elementType) =>
@@ -79,7 +77,7 @@ namespace SlackNet
         private object ReadObject(JsonReader reader, Type objectType, JsonSerializer serializer)
         {
             var jObject = JObject.Load(reader);
-            var targetType = GetType(jObject, objectType) ?? objectType;
+            var targetType = GetType(jObject, objectType);
             return ReadInner(CreateAnotherReader(jObject, reader), targetType, serializer);
         }
 
@@ -96,22 +94,18 @@ namespace SlackNet
             return jObjectReader;
         }
 
-        private Type GetType(JObject jObject, Type parentType)
+        private Type GetType(JToken jObject, Type parentType)
         {
-            if (jObject.Value<uint>("reply_to") > 0)
-                return typeof(Reply);
+            if (jObject.Value<uint>("reply_to") > 0) return typeof(Reply);
 
             var type = GetType(jObject, "type", parentType);
-            return type == null ? null
-                : GetType(jObject, "subtype", type)
-                ?? type;
+            return GetType(jObject, "subtype", type);
         }
 
-        private Type GetType(JObject jObject, string typeProperty, Type baseType)
+        private Type GetType(JToken jObject, string typeProperty, Type baseType)
         {
             var slackType = jObject.Value<string>(typeProperty);
-            return slackType == null ? null
-                : _slackTypeResolver.FindType(baseType, slackType);
+            return slackType == null ? baseType : _slackTypeResolver.FindType(baseType, slackType);
         }
 
         private static object ReadInner(JsonReader reader, Type objectType, JsonSerializer serializer)

--- a/SlackNet/Serialization/SlackTypeConverter.cs
+++ b/SlackNet/Serialization/SlackTypeConverter.cs
@@ -12,8 +12,8 @@ namespace SlackNet
     class SlackTypeConverter : JsonConverter
     {
         private readonly ISlackTypeResolver _slackTypeResolver;
-        private bool _isInsideRead;
-        private JsonReader _reader;
+        [ThreadStatic] private static bool _isInsideRead;
+        [ThreadStatic] private static JsonReader _reader;
 
         public SlackTypeConverter(ISlackTypeResolver slackTypeResolver)
         {
@@ -114,7 +114,7 @@ namespace SlackNet
                 : _slackTypeResolver.FindType(baseType, slackType);
         }
 
-        private object ReadInner(JsonReader reader, Type objectType, JsonSerializer serializer)
+        private static object ReadInner(JsonReader reader, Type objectType, JsonSerializer serializer)
         {
             _reader = reader;
             _isInsideRead = true;


### PR DESCRIPTION
Hi Simon!

When we run a load test in our project, we encountered a problem with SlackTypeConverter. After a certain threshold is reached, deserialization on some requests fails, and it starts throwing errors because of that. 

We spent some time investigating what's the root cause of it, and we pinpointed it down to a problem that was fixed in manuc66/JsonSubTypes#19 (thank you for your comment which references this repo!).

After including this change, deserialization no longer fails, no matter how much we increase the number of concurrent requests.

Thank you for your work on SlackNet!