### PR TITLE
[FEATURE] Make event url verification optional

### DIFF
--- a/SlackNet.AspNetCore/SlackEndpointConfiguration.cs
+++ b/SlackNet.AspNetCore/SlackEndpointConfiguration.cs
@@ -35,9 +35,16 @@
             SigningSecret = signingSecret;
             return this;
         }
+        
+        public SlackEndpointConfiguration UseEventUrlVerification(bool verifyEventUrl)
+        {
+            VerifyEventUrl = verifyEventUrl;
+            return this;
+        }
 
         public string RoutePrefix { get; private set; } = "slack";
         public string VerificationToken { get; private set; }
         public string SigningSecret { get; private set; }
+        public bool VerifyEventUrl { get; private set; } = true;
     }
 }

--- a/SlackNet.AspNetCore/SlackRequestHandler.cs
+++ b/SlackNet.AspNetCore/SlackRequestHandler.cs
@@ -75,7 +75,10 @@ namespace SlackNet.AspNetCore
             var requestBody = await ReadString(request).ConfigureAwait(false);
             var eventRequest = DeserializeEventRequest(requestBody);
 
-            if (!VerifyRequest(requestBody, request.Headers, eventRequest.Token, config))
+            var shouldSkipVerification = eventRequest is UrlVerification && !config.VerifyEventUrl;
+            var isRequestVerified = shouldSkipVerification || VerifyRequest(requestBody, request.Headers, eventRequest.Token, config);
+            
+            if (!isRequestVerified)
                 return new StringResult(HttpStatusCode.BadRequest, "Invalid signature/token");
 
             switch (eventRequest)


### PR DESCRIPTION
Hi, me again! This PR will seem a bit weird, but I'll try to explain the reasoning for it. 🙈 

We submitted an app to the Slack directory and it got approved. Hooray! After some time we decided that we'd like to change a domain pointing to our server, and what seemed to be an easy thing to do, became a problem.

When the app is accepted in the Slack directory, they generate a second set of keys (client ID, client secret, even the app ID itself) for you. Your first set of keys is used in a published version, but you can use a second set for a staging version of the app, so you can test out features before you publish them to the public. So far, so good.

The problem is in the fact that Slack only gives you one URL you can set (for events, slash commands, etc), so you can't easily differentiate between published version and staging. In addition to that, if you want to change your event request URL in the Slack interface, it'll send a request to it using the staging set of keys. Of course, because of that, SlackNet won't be able to verify the request, and the challenge won't be successful.

We've talked to Slack support about how to proceed, and they answered this:

> We’re hoping that if you need to update your Event Subscriptions Request URL endpoint that you temporarily update the “signing secret” in your code to accept the value for the “beta” app.
However, if you can’t do that, then since your endpoint still needs to send back a “challenge” request, it shouldn’t be a big deal to skip the signature verification aspect since it’s already a 2-step process (manual configuration + challenge response).
Hopefully, that makes sense, and you can make the needed adjustments when updating your Event Subscriptions Request URL endpoint.
We’ll be here if you have any further questions about this.
Aubrey

The first approach doesn't make a lot of sense to me, because I don't want to update signing secret of my production app since that'd make it unavailable to the public for a brief period of time, but I don't see a problem in temporarily disabling URL verification.  

I know this is a weirdly specific thing to add to SlackNet, but I guess there's a good possibility someone else will have a same problem, so why not give them an easy (and Slack approved) workaround?

Hope this makes sense to you.