### PR TITLE
[FEATURE] Authorizations

### DIFF
--- a/SlackNet/Events/EventCallback.cs
+++ b/SlackNet/Events/EventCallback.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace SlackNet.Events
@@ -12,6 +13,8 @@ namespace SlackNet.Events
         public string ApiAppId { get; set; }
         public Event Event { get; set; }
         public string[] AuthedUsers { get; set; }
+        public IList<Authorization> Authorizations { get; set; }
+        public string EventContext { get; set; }
         public string EventId { get; set; }
         public int EventTime { get; set; }
         [JsonIgnore]

--- a/SlackNet/Objects/Authorization.cs
+++ b/SlackNet/Objects/Authorization.cs
@@ -1,0 +1,19 @@
+namespace SlackNet
+{
+    /// <summary>
+    /// An installation of your app. Installations are defined by a combination of the installing Enterprise Grid org,
+    /// workspace, and user (represented by <see cref="EnterpriseId"/>, <see cref="TeamId"/> and <see cref="UserId"/> inside this class)
+    /// Installations may only have one or two, not all three, defined.
+    /// </summary>
+    public class Authorization
+    {
+        public string EnterpriseId { get; set; }
+
+        public string TeamId { get; set; }
+
+        public string UserId { get; set; }
+        
+        public bool IsBot { get; set; }
+            
+    }
+}

--- a/SlackNet/WebApi/AppsEventsAuthorizationsApi.cs
+++ b/SlackNet/WebApi/AppsEventsAuthorizationsApi.cs
@@ -1,0 +1,59 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Args = System.Collections.Generic.Dictionary<string, object>;
+
+namespace SlackNet.WebApi
+{
+    public interface IAppsEventsAuthorizationsApi
+    {
+        /// <summary>
+        /// Get a list of authorizations for the given event context. Should always be used with app token type.
+        /// </summary>
+        /// <param name="eventContext">	An identifier for a specific event.</param>
+        /// <param name="limit">The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.</param>
+        /// <param name="cursor">
+        /// Paginate through collections of data by setting the cursor parameter to a <see cref="ResponseMetadata.NextCursor"/> property
+        /// returned by a previous request's <see cref="AppsEventsAuthorizationsListResponse.ResponseMetadata"/>.
+        /// Default value fetches the first "page" of the collection.
+        /// </param>
+        /// <param name="cancellationToken"></param>
+        Task<AppsEventsAuthorizationsListResponse> List(
+            string eventContext,
+            int limit = 100,
+            string cursor = null,
+            CancellationToken? cancellationToken = null);
+    }
+
+    public class AppsEventsAuthorizationsApi : IAppsEventsAuthorizationsApi
+    {
+        private readonly ISlackApiClient _client;
+
+        public AppsEventsAuthorizationsApi(ISlackApiClient client) => _client = client;
+
+        /// <summary>
+        /// Get a list of authorizations for the given event context.
+        /// </summary>
+        /// <param name="eventContext">	An identifier for a specific event.</param>
+        /// <param name="limit">The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.</param>
+        /// <param name="cursor">
+        /// Paginate through collections of data by setting the cursor parameter to a <see cref="ResponseMetadata.NextCursor"/> property
+        /// returned by a previous request's <see cref="AppsEventsAuthorizationsListResponse.ResponseMetadata"/>.
+        /// Default value fetches the first "page" of the collection.
+        /// </param>
+        /// <param name="cancellationToken"></param>
+        public Task<AppsEventsAuthorizationsListResponse> List(
+            string eventContext,
+            int limit = 100,
+            string cursor = null,
+            CancellationToken? cancellationToken = null)
+            => _client.Post<AppsEventsAuthorizationsListResponse>(
+                "apps.events.authorizations.list",
+                new Args
+                    {
+                        { "event_context", eventContext },
+                        { "cursor", cursor },
+                        { "limit", limit },
+                    },
+                cancellationToken);
+    }
+}

--- a/SlackNet/WebApi/Responses/AppsEventsAuthorizationsListResponse.cs
+++ b/SlackNet/WebApi/Responses/AppsEventsAuthorizationsListResponse.cs
@@ -5,6 +5,6 @@ namespace SlackNet.WebApi
     public class AppsEventsAuthorizationsListResponse
     {
         public IList<Authorization> Authorizations { get; set; }  = new List<Authorization>();
-        public ResponseMetadata ResponseMetadata { get; set; } = new ResponseMetadata();
+        public string CursorNext { get; set; }
     }
 }

--- a/SlackNet/WebApi/Responses/AppsEventsAuthorizationsListResponse.cs
+++ b/SlackNet/WebApi/Responses/AppsEventsAuthorizationsListResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace SlackNet.WebApi
+{
+    public class AppsEventsAuthorizationsListResponse
+    {
+        public IList<Authorization> Authorizations { get; set; }  = new List<Authorization>();
+        public ResponseMetadata ResponseMetadata { get; set; } = new ResponseMetadata();
+    }
+}


### PR DESCRIPTION
Hi Simon! 👋 

Slack is deprecating `authed_users` and `authed_teams` from the `event` payload and replacing it with `authorizations` field and `apps.event.authorizations.list`. This change will take place on February 24, 2021, but apps can opt-in before that. More about that [here](https://api.slack.com/changelog/2020-09-15-events-api-truncate-authed-users).

This PR adds the things mentioned above. I'll leave it up to you to decide if you'd like to mark `authed_users` and `authed_teams` as deprecated. 

Cheers! 🍻 