### PR TITLE
Add additional properties to app mention - (fixes #66)

### DIFF
--- a/SlackNet/Events/AppMention.cs
+++ b/SlackNet/Events/AppMention.cs
@@ -1,5 +1,7 @@
 using Newtonsoft.Json;
+using SlackNet.Blocks;
 using System;
+using System.Collections.Generic;
 
 namespace SlackNet.Events
 {
@@ -15,5 +17,14 @@ namespace SlackNet.Events
         public DateTime Timestamp => Ts.ToDateTime().GetValueOrDefault();
         public string Channel { get; set; }
         public string EventTs { get; set; }
+        public string Subtype { get; set; }
+        public string ThreadTs { get; set; }
+        [JsonIgnore]
+        public DateTime? ThreadTimestamp => ThreadTs.ToDateTime();
+        public IList<Attachment> Attachments { get; set; } = new List<Attachment>();
+        public IList<Block> Blocks { get; set; } = new List<Block>();
+        public Edit Edited { get; set; }
+        public IList<File> Files { get; set; } = new List<File>();
+        public bool Upload { get; set; }
     }
 }


### PR DESCRIPTION
Adds additional properties to the app mention event. I added the properties from the existing `MessageEvent` that I could also find on the app_mention event payload below. This was an edited mention in a thread and included a file attachment and link.
``` 
    "event": {
        "type": "app_mention",
        "text": "<@...> edited broadcast threaded mention with attachment <https://google.com>",
        "files": [
           ...
        ],
        "upload": false,
        "blocks": [
            ...
        ],
        "user": "...",
        "display_as_bot": false,
        "ts": "1604738785.007800",
        "edited": {...}
        "thread_ts": "1604738675.007700",
        "parent_user_id": "...",
        "subtype": "thread_broadcast",
        "root": {
            "client_msg_id": "...",
            "type": "message",
            "text": "root message",
            "user": "...",
            "ts": "1604738675.007700",
            "team": "...",
            "blocks": [
               ...
            ],
            "thread_ts": "1604738675.007700",
            "reply_count": 2,
            "reply_users_count": 1,
            "latest_reply": "1604738952.008900",
            "reply_users": [
                "..."
            ],
            "subscribed": false
        },
        "attachments": [
            ...
        ],
        "channel": "...",
        "event_ts": "1604738785.007800"
    }, 
```

- There are a few properties included above that I didn't add - Instead opted for just the one you had already defined elsewhere at least until I understand the API and interactions a bit more.  
- In particular the thread broadcast added the `root` property. I couldn't find a matching SlackType defined for `thread_broadcast` or any existing root types or properties so might be something that needs to be checked elsewhere too. 
- The message event has properties for `pinned_to` `is_starred` and `reactions` - but I couldn't get any of these properties to come through on the mention events so left them off - they must not be included in mentions. 

fixes #66
