### PR TITLE
Fix bug where user blocks are not deserialised

### DIFF
--- a/SlackNet/Blocks/RichTextBlock.cs
+++ b/SlackNet/Blocks/RichTextBlock.cs
@@ -41,7 +41,7 @@ namespace SlackNet.Blocks
     }
 
     [SlackType("user")]
-    public class RichTextUser
+    public class RichTextUser : RichTextSectionElement
     {
         public string UserId { get; set; }
         public RichTextStyle Style { get; set; } = new RichTextStyle();


### PR DESCRIPTION
Noticed that user mentions in the `Blocks` collection are coming through as `null` and a `Couldn't deserialize, fallback to default value.` message was being shown in the console. 

The underlying exception indicated that it was attempting to create an instance of `RichTextSectionElement` which is an abstract class. Assuming this is because it's looking for a `user` subtype that extends this base class and can't find one. 

I haven't had a chance to validate this fixes the issue yet, but thought I'd put the PR up while I was doing the other one. 

