### PR TITLE
Add Files and Block to SlackBot SlackMessage

### DIFF
--- a/SlackNet.Bot/IMessage.cs
+++ b/SlackNet.Bot/IMessage.cs
@@ -18,6 +18,9 @@ namespace SlackNet.Bot
         string ThreadTs { get; set; }
         DateTime ThreadTimestamp { get; }
         IList<Attachment> Attachments { get; set; }
+
+        IList<File> Files { get; set; }
+
         IList<Block> Blocks { get; set; }
         bool IsInThread { get; }
         bool MentionsBot { get; }

--- a/SlackNet.Bot/SlackBot.cs
+++ b/SlackNet.Bot/SlackBot.cs
@@ -294,7 +294,9 @@ namespace SlackNet.Bot
                     User = await user.ConfigureAwait(false),
                     Conversation = await conversation.ConfigureAwait(false),
                     Hub = await hub.ConfigureAwait(false),
-                    Attachments = message.Attachments
+                    Attachments = message.Attachments,
+                    Files = message.Files,
+                    Blocks = message.Blocks
                 };
         }
 

--- a/SlackNet.Bot/SlackMessage.cs
+++ b/SlackNet.Bot/SlackMessage.cs
@@ -24,6 +24,9 @@ namespace SlackNet.Bot
         [JsonIgnore]
         public DateTime ThreadTimestamp => Ts.ToDateTime().GetValueOrDefault();
         public IList<Attachment> Attachments { get; set; } = new List<Attachment>();
+
+        public IList<File> Files { get; set; } = new List<File>();
+
         public IList<Block> Blocks { get; set; } = new List<Block>();
         public bool IsInThread => ThreadTs != null;
 
@@ -32,7 +35,7 @@ namespace SlackNet.Bot
             || Text.IndexOf(_bot.Name, StringComparison.OrdinalIgnoreCase) >= 0
             || Conversation?.IsIm == true;
 
-        public Task ReplyWith(string text, bool createThread = false, CancellationToken? cancellationToken = null) => 
+        public Task ReplyWith(string text, bool createThread = false, CancellationToken? cancellationToken = null) =>
             ReplyWith(new BotMessage { Text = text }, createThread, cancellationToken);
 
         public async Task ReplyWith(Func<Task<BotMessage>> createReply, bool createThread = false, CancellationToken? cancellationToken = null)


### PR DESCRIPTION
- fixed: `SlackBot.CreateSlackMessage`: missing assignment of `Blocks`
- added: `SlackBot.CreateSlackMessage`: added assignment of `Files`
- added: `IMessage.Files` and `SlackMessage.Files` List

closes soxtoby issue #77