### PR TITLE
Update Build.cs

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -45,8 +45,6 @@ class Build : NukeBuild
         .DependsOn(Restore)
         .Executes(() =>
         {
-            AppVeyor.Instance?.UpdateBuildVersion(GitVersion.FullSemVer);
-
             DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)


### PR DESCRIPTION
That call should not be needed, as the `GitVersion` attribute will already update the AppVeyor build number. Also, as it currently is, it will fail multiple AppVeyor builds for the same commit.