### PR TITLE
Added missing properties to FileShared event

### DIFF
--- a/SlackNet/Events/FileShared.cs
+++ b/SlackNet/Events/FileShared.cs
@@ -6,6 +6,8 @@ namespace SlackNet.Events
     public class FileShared : Event
     {
         public string FileId { get; set; }
+        public string ChannelId { get; set; }
+        public string UserId { get; set; }      
         public FileId File { get; set; }
     }
 }


### PR DESCRIPTION
According to the event information 
https://api.slack.com/events/file_shared
The `user_id` and `channel_id`  are missing.