### PR TITLE
Sign in with Slack support via Open ID api methods

### DIFF
--- a/SlackNet.Tests/ApiLintTest.cs
+++ b/SlackNet.Tests/ApiLintTest.cs
@@ -204,6 +204,7 @@ namespace SlackNet.Tests
             public IMigrationApi Migration { get; }
             public IOAuthApi OAuth { get; }
             public IOAuthV2Api OAuthV2 { get; }
+            public IOpenIdApi OpenIdApi { get; }
             public IPinsApi Pins { get; }
             public IReactionsApi Reactions { get; }
             public IRemindersApi Reminders { get; }

--- a/SlackNet.Tests/Configuration/FactorySlackHandlerConfigurationTests.cs
+++ b/SlackNet.Tests/Configuration/FactorySlackHandlerConfigurationTests.cs
@@ -969,6 +969,7 @@ namespace SlackNet.Tests.Configuration
             public IMigrationApi Migration { get; }
             public IOAuthApi OAuth { get; }
             public IOAuthV2Api OAuthV2 { get; }
+            public IOpenIdApi OpenIdApi { get; }
             public IPinsApi Pins { get; }
             public IReactionsApi Reactions { get; }
             public IRemindersApi Reminders { get; }

--- a/SlackNet/SlackApiClient.cs
+++ b/SlackNet/SlackApiClient.cs
@@ -29,6 +29,7 @@ namespace SlackNet
         IMigrationApi Migration { get; }
         IOAuthApi OAuth { get; }
         IOAuthV2Api OAuthV2 { get; }
+        IOpenIdApi OpenIdApi { get; }
         IPinsApi Pins { get; }
         IReactionsApi Reactions { get; }
         IRemindersApi Reminders { get; }
@@ -161,6 +162,7 @@ namespace SlackNet
         public IMigrationApi Migration => new MigrationApi(this);
         public IOAuthApi OAuth => new OAuthApi(this);
         public IOAuthV2Api OAuthV2 => new OAuthV2Api(this);
+        public IOpenIdApi OpenIdApi => new OpenIdApi(this);
         public IPinsApi Pins => new PinsApi(this);
         public IReactionsApi Reactions => new ReactionsApi(this);
         public IRemindersApi Reminders => new RemindersApi(this);

--- a/SlackNet/WebApi/OpenIdApi.cs
+++ b/SlackNet/WebApi/OpenIdApi.cs
@@ -32,13 +32,12 @@ namespace SlackNet.WebApi
         /// <summary>
         /// Get the identity of a user who has authorized Sign in with Slack.
         /// See https://api.slack.com/methods/openid.connect.userInfo for more information.
+        /// Note: that this method uses an Authentication token passed in the header.
+        /// Use <c>SlackApiClient.WithAccessToken</c> to specify a token.
         /// </summary>
         /// <param name="token">Authentication token bearing required scopes. Tokens should be passed as an HTTP Authorization header or alternatively, as a POST parameter.</param>
         /// <param name="cancellationToken"></param>
-        Task<OpenIdUserInfoResponse> UserInfo(
-            string token,
-            CancellationToken? cancellationToken
-        );
+        Task<OpenIdUserInfoResponse> UserInfo(CancellationToken? cancellationToken);
 
   }
 
@@ -82,14 +81,12 @@ namespace SlackNet.WebApi
         /// <summary>
         /// Get the identity of a user who has authorized Sign in with Slack.
         /// See https://api.slack.com/methods/openid.connect.userInfo for more information.
+        /// Note: that this method uses an Authentication token passed in the header.
+        /// Use <c>SlackApiClient.WithAccessToken</c> to specify a token.
         /// </summary>
         /// <param name="token">Authentication token bearing required scopes. Tokens should be passed as an HTTP Authorization header or alternatively, as a POST parameter.</param>
         /// <param name="cancellationToken"></param>
-        public Task<OpenIdUserInfoResponse> UserInfo(
-            string token,
-            CancellationToken? cancellationToken = null
-        ) => _client.Post<OpenIdUserInfoResponse>("openid.connect.userInfo", new Args {
-            { "token", token }
-        }, cancellationToken);
+        public Task<OpenIdUserInfoResponse> UserInfo(CancellationToken? cancellationToken = null) =>
+            _client.Post<OpenIdUserInfoResponse>("openid.connect.userInfo", new Args { }, cancellationToken);
     }
 }

--- a/SlackNet/WebApi/OpenIdApi.cs
+++ b/SlackNet/WebApi/OpenIdApi.cs
@@ -87,7 +87,7 @@ namespace SlackNet.WebApi
         /// <param name="cancellationToken"></param>
         public Task<OpenIdUserInfoResponse> UserInfo(
             string token,
-            CancellationToken? cancellationToken
+            CancellationToken? cancellationToken = null
         ) => _client.Post<OpenIdUserInfoResponse>("openid.connect.userInfo", new Args {
             { "token", token }
         }, cancellationToken);

--- a/SlackNet/WebApi/OpenIdApi.cs
+++ b/SlackNet/WebApi/OpenIdApi.cs
@@ -1,0 +1,95 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Args = System.Collections.Generic.Dictionary<string, object>;
+
+namespace SlackNet.WebApi
+{
+    public interface IOpenIdApi
+    {
+        /// <summary>
+        /// Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
+        /// See https://api.slack.com/methods/openid.connect.token for more information.
+        /// </summary>
+        /// <param name="clientId">Issued when you created your application.</param>
+        /// <param name="clientSecret">Issued when you created your application.</param>
+        /// <param name="code">The code param returned via the OAuth callback.</param>
+        /// <param name="grantType">The grant_type param as described in the OAuth spec.</param>
+        /// <param name="redirectUrl">This must match the originally submitted URI (if one was sent).</param>
+        /// <param name="refreshToken">The refresh_token param as described in the OAuth spec.</param>
+        /// <param name="cancellationToken"></param>
+        Task<OpenIdTokenResponse> Token(
+            string clientId,
+            string clientSecret,
+#nullable enable
+            string? code,
+            string? grantType,
+            string? redirectUrl,
+            string? refreshToken,
+#nullable disable
+            CancellationToken? cancellationToken
+        );
+
+        /// <summary>
+        /// Get the identity of a user who has authorized Sign in with Slack.
+        /// See https://api.slack.com/methods/openid.connect.userInfo for more information.
+        /// </summary>
+        /// <param name="token">Authentication token bearing required scopes. Tokens should be passed as an HTTP Authorization header or alternatively, as a POST parameter.</param>
+        /// <param name="cancellationToken"></param>
+        Task<OpenIdUserInfoResponse> UserInfo(
+            string token,
+            CancellationToken? cancellationToken
+        );
+
+  }
+
+    public class OpenIdApi : IOpenIdApi
+    {
+        private readonly ISlackApiClient _client;
+        public OpenIdApi(ISlackApiClient client) => _client = client;
+
+        /// <summary>
+        /// Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
+        /// See https://api.slack.com/methods/openid.connect.token for more information.
+        /// </summary>
+        /// <param name="clientId">Issued when you created your application.</param>
+        /// <param name="clientSecret">Issued when you created your application.</param>
+        /// <param name="code">The code param returned via the OAuth callback.</param>
+        /// <param name="grantType">The grant_type param as described in the OAuth spec.</param>
+        /// <param name="redirectUrl">This must match the originally submitted URI (if one was sent).</param>
+        /// <param name="refreshToken">The refresh_token param as described in the OAuth spec.</param>
+        /// <param name="cancellationToken"></param>
+        public Task<OpenIdTokenResponse> Token(
+            string clientId,
+            string clientSecret,
+#nullable enable
+            string? code,
+            string? grantType,
+            string? redirectUrl,
+            string? refreshToken,
+#nullable disable
+            CancellationToken? cancellationToken = null
+         ) => _client.Post<OpenIdTokenResponse>("openid.connect.token", new Args
+                {
+                    { "client_id", clientId },
+                    { "client_secret", clientSecret },
+                    { "code", code },
+                    { "grant_type", grantType },
+                    { "redirect_uri", redirectUrl },
+                    { "refresh_token", refreshToken }
+                }, cancellationToken);
+
+
+        /// <summary>
+        /// Get the identity of a user who has authorized Sign in with Slack.
+        /// See https://api.slack.com/methods/openid.connect.userInfo for more information.
+        /// </summary>
+        /// <param name="token">Authentication token bearing required scopes. Tokens should be passed as an HTTP Authorization header or alternatively, as a POST parameter.</param>
+        /// <param name="cancellationToken"></param>
+        public Task<OpenIdUserInfoResponse> UserInfo(
+            string token,
+            CancellationToken? cancellationToken
+        ) => _client.Post<OpenIdUserInfoResponse>("openid.connect.userInfo", new Args {
+            { "token", token }
+        }, cancellationToken);
+    }
+}

--- a/SlackNet/WebApi/Responses/OpenIdTokenResponse.cs
+++ b/SlackNet/WebApi/Responses/OpenIdTokenResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace SlackNet.WebApi
+{
+    public class OpenIdTokenResponse
+    {
+        public bool Ok { get; set; }
+        public string AccessToken { get; set; }
+        public string TokenType { get; set; }
+        public string IdToken { get; set; }
+    }
+}

--- a/SlackNet/WebApi/Responses/OpenIdUserInfoResponse.cs
+++ b/SlackNet/WebApi/Responses/OpenIdUserInfoResponse.cs
@@ -1,0 +1,60 @@
+﻿using Newtonsoft.Json;
+
+namespace SlackNet.WebApi
+{
+    public class OpenIdUserInfoResponse
+    {
+        string Ok { get; set; }
+        string Sub { get; set; }
+
+        [JsonProperty("https://slack.com/user_id")]
+        string UserId { get; set; }
+
+        [JsonProperty("https://slack.com/team_id")]
+        string TeamId { get; set; }
+
+        string Email { get; set; }
+        string EmailVerified { get; set; }
+        string DateEmailVerified { get; set; }
+        string Name { get; set; }
+        string Picture { get; set; }
+        string GivenName { get; set; }
+        string FamilyName { get; set; }
+        string Locale { get; set; }
+
+        [JsonProperty("https://slack.com/team_name")]
+        string TeamName { get; set; }
+        [JsonProperty("https://slack.com/team_domain")]
+        string TeamDomain { get; set; }
+
+        [JsonProperty("https://slack.com/user_image_24")]
+        string UserImage24 { get; set; }
+        [JsonProperty("https://slack.com/user_image_32")]
+        string UserImage32 { get; set; }
+        [JsonProperty("https://slack.com/user_image_48")]
+        string UserImage48 { get; set; }
+        [JsonProperty("https://slack.com/user_image_72")]
+        string UserImage72 { get; set; }
+        [JsonProperty("https://slack.com/user_image_192")]
+        string UserImage192 { get; set; }
+        [JsonProperty("https://slack.com/user_image_512")]
+        string UserImage512 { get; set; }
+
+        [JsonProperty("https://slack.com/team_image_34")]
+        string TeamImage34 { get; set; }
+        [JsonProperty("https://slack.com/team_image_44")]
+        string TeamImage44 { get; set; }
+        [JsonProperty("https://slack.com/team_image_68")]
+        string TeamImage68 { get; set; }
+        [JsonProperty("https://slack.com/team_image_88")]
+        string TeamImage88 { get; set; }
+        [JsonProperty("https://slack.com/team_image_102")]
+        string TeamImage102 { get; set; }
+        [JsonProperty("https://slack.com/team_image_132")]
+        string TeamImage132 { get; set; }
+        [JsonProperty("https://slack.com/team_image_230")]
+        string TeamImage230 { get; set; }
+        [JsonProperty("https://slack.com/team_image_default")]
+        string TeamImageDefault { get; set; }
+    }
+}


### PR DESCRIPTION
The "Sign in with Slack" workflow is built on top of the OAuth 2.0 flow and looks like the same endpoints. It seems as if the different scopes only change the encoded JWT as part of the "token" response.
https://api.slack.com/authentication/sign-in-with-slack

OpenId client implemented supporting both the [token](https://api.slack.com/methods/openid.connect.token) and the [userInfo](https://api.slack.com/methods/openid.connect.userInfo) endpoints.


