### PR TITLE
Additional members for openid.connect.token response.

### DIFF
--- a/SlackNet/WebApi/Responses/OpenIdTokenResponse.cs
+++ b/SlackNet/WebApi/Responses/OpenIdTokenResponse.cs
@@ -6,5 +6,8 @@
         public string AccessToken { get; set; }
         public string TokenType { get; set; }
         public string IdToken { get; set; }
+        public string State { get; set; }
+        public string RefreshToken { get; set; }
+        public int ExpiresIn { get; set; }
     }
 }


### PR DESCRIPTION
Thanks to the amazing documentation with detailed examples from Slack, I was able to first time get the complete response from the `openid.connect.token` endpoint! 
If token rotation and openid both are used on the same application, the endpoint will be either:

_grant_type: authorization_code_
```json
{
  "ok": true,
  "access_token": "xoxe.xoxp-1-...",
  "token_type": "Bearer",
  "id_token": "eyJh...",
  "state": "RandomValue2",
  "refresh_token": "xoxe-1-...",
  "expires_in": 43200
}
```
_grant_type: refresh_token_
```json
{
  "ok": true,
  "access_token": "xoxe.xoxp-1-...",
  "token_type": "Bearer",
  "refresh_token": "xoxe-1-...",
  "expires_in": 43200
}
```

So I added state, refresh_token, and expires_in. 