### PR TITLE
SetPresence does not clear the away status.

### DIFF
--- a/SlackNet.Tests/ApiLintTest.cs
+++ b/SlackNet.Tests/ApiLintTest.cs
@@ -112,7 +112,7 @@ namespace SlackNet.Tests
                 { typeof(SortBy), _ => SortBy.Score },
                 { typeof(SortDirection), _ => SortDirection.Ascending },
                 { typeof(ProfileFieldVisibility), _ => ProfileFieldVisibility.All },
-                { typeof(Presence), _ => Presence.Active },
+                { typeof(Presence), _ => Presence.Auto },
                 { typeof(ChangeType?), _ => null },
                 { typeof(IEnumerable<ConversationType>), _ => Enumerable.Empty<ConversationType>() },
                 { typeof(IEnumerable<FileType>), _ => Enumerable.Empty<FileType>() },

--- a/SlackNet/Objects/Presence.cs
+++ b/SlackNet/Objects/Presence.cs
@@ -2,7 +2,7 @@
 {
     public enum Presence
     {
-        Active,
+        Auto,
         Away
     }
 }


### PR DESCRIPTION
The current Presence enum uses "Active" and "Away" as valid arguments. By passing "Active" to the server it returns "invalid_arguments" since the current valid API values are "Auto" and "Away".

https://api.slack.com/methods/users.setPresence