### PR TITLE
Improve Documentation for .NET Core API Slack Event Subscriptions

### DIFF
--- a/SlackNet.EventsAspNetCoreExample/Controllers/SlackController.cs
+++ b/SlackNet.EventsAspNetCoreExample/Controllers/SlackController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using SlackNet.AspNetCore;
+using SlackNet.EventsAspNetCoreExample.Models;
+
+namespace SlackNet.EventsAspNetCoreExample.Controllers
+{
+    [ApiController]
+    public class SlackController : ControllerBase
+    {
+        private readonly ISlackRequestHandler _requestHandler;
+        private readonly SlackEndpointConfiguration _endpointConfig;
+        private readonly ISlackApiClient _slack;
+        public SlackController(ISlackRequestHandler requestHandler, SlackEndpointConfiguration endpointConfig, ISlackApiClient slack)
+        {
+            _requestHandler = requestHandler;
+            _endpointConfig = endpointConfig;
+            _slack = slack;
+        }
+
+        [HttpPost]
+        [Route("[Controller]/Submit")]
+        public async Task<ActionResult> Submit([FromBody] SlackRequest request)
+        {
+            await _slack.Chat.PostMessage(new SlackNet.WebApi.Message() { Text = request.Message, Channel = request.SlackChannel }, null);
+            return Ok();
+        }
+
+        [HttpPost]
+        [Route("[Controller]/Event")]
+        public async Task<IActionResult> Event()
+        {
+            return await _requestHandler.HandleEventRequest(HttpContext.Request, _endpointConfig);
+        }
+
+    }
+}

--- a/SlackNet.EventsAspNetCoreExample/Handlers/PingHandler.cs
+++ b/SlackNet.EventsAspNetCoreExample/Handlers/PingHandler.cs
@@ -1,0 +1,27 @@
+﻿using SlackNet.Events;
+using SlackNet.WebApi;
+
+namespace SlackNet.EventsAspNetCoreExample.Handlers
+{
+    public class PingHandler : IEventHandler<MessageEvent>
+    {
+
+        private readonly ISlackApiClient _slack;
+        public PingHandler(ISlackApiClient slack)
+        {
+            _slack = slack;
+        }
+
+        public async Task Handle(MessageEvent slackEvent)
+        {
+            if (slackEvent.Text.Contains("ping"))
+            {
+                await _slack.Chat.PostMessage(new Message
+                {
+                    Text = "pong",
+                    Channel = slackEvent.Channel
+                }).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/SlackNet.EventsAspNetCoreExample/Models/Settings.cs
+++ b/SlackNet.EventsAspNetCoreExample/Models/Settings.cs
@@ -1,0 +1,8 @@
+﻿namespace SlackNet.EventsAspNetCoreExample.Models
+{
+    public class Settings
+    {
+        public string SlackAccessToken { get; set; }
+        public string SlackSigningSecret { get; set; }
+    }
+}

--- a/SlackNet.EventsAspNetCoreExample/Models/SlackRequest.cs
+++ b/SlackNet.EventsAspNetCoreExample/Models/SlackRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace SlackNet.EventsAspNetCoreExample.Models
+{
+    public class SlackRequest
+    {
+        public string SlackChannel { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/SlackNet.EventsAspNetCoreExample/Program.cs
+++ b/SlackNet.EventsAspNetCoreExample/Program.cs
@@ -1,5 +1,3 @@
-
-
 using SlackNet.AspNetCore;
 using SlackNet.Events;
 using SlackNet.EventsAspNetCoreExample.Handlers;

--- a/SlackNet.EventsAspNetCoreExample/Program.cs
+++ b/SlackNet.EventsAspNetCoreExample/Program.cs
@@ -1,0 +1,40 @@
+
+
+using SlackNet.AspNetCore;
+using SlackNet.Events;
+using SlackNet.EventsAspNetCoreExample.Handlers;
+using SlackNet.EventsAspNetCoreExample.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var settings = builder.Configuration.GetSection("Slack").Get<Settings>();
+
+var accessToken = Environment.GetEnvironmentVariable("SlackAccessToken") ?? settings.SlackAccessToken;
+var signingSecret = Environment.GetEnvironmentVariable("SlackSigningSecret") ?? settings.SlackSigningSecret;
+
+
+#if DEBUG
+builder.Services.AddSingleton(new SlackEndpointConfiguration());
+#else
+builder.Services.AddSingleton(new SlackEndpointConfiguration().UseSigningSecret(signingSecret));
+#endif
+
+builder.Services.AddSlackNet(c => c
+.UseApiToken(accessToken)
+.RegisterEventHandler<MessageEvent, PingHandler>());
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+app.UseHttpsRedirection();
+app.MapControllers();
+
+app.Run();
+

--- a/SlackNet.EventsAspNetCoreExample/Properties/launchSettings.json
+++ b/SlackNet.EventsAspNetCoreExample/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:49652",
+      "sslPort": 44374
+    }
+  },
+  "profiles": {
+    "SlackNet.EventsAspNetCoreExample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7226;http://localhost:5226",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/SlackNet.EventsAspNetCoreExample/SlackNet.EventsAspNetCoreExample.csproj
+++ b/SlackNet.EventsAspNetCoreExample/SlackNet.EventsAspNetCoreExample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SlackNet.AspNetCore\SlackNet.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SlackNet.EventsAspNetCoreExample/appsettings.Development.json
+++ b/SlackNet.EventsAspNetCoreExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/SlackNet.EventsAspNetCoreExample/appsettings.json
+++ b/SlackNet.EventsAspNetCoreExample/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Slack": {
+    "SlackAccessToken": "<slack access token here>",
+    "SlackSigningSecret": "<slack signing secret here>"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/SlackNet.EventsAspNetCoreExample/readme.md
+++ b/SlackNet.EventsAspNetCoreExample/readme.md
@@ -1,3 +1,2 @@
 ﻿# ASP.NET Core 6 Events Example
-
 [Documentation](https://medium.com/@justinshawngerber/how-to-create-a-simple-slackbot-using-c-and-net-6-ebfec7692f41)

--- a/SlackNet.EventsAspNetCoreExample/readme.md
+++ b/SlackNet.EventsAspNetCoreExample/readme.md
@@ -1,3 +1,3 @@
-﻿# ASP.NET Core Events Example
+﻿# ASP.NET Core 6 Events Example
 
-Documentation can be found here https://medium.com/@justinshawngerber/how-to-create-a-simple-slackbot-using-c-and-net-6-ebfec7692f41
+[Documentation](https://github.com/soxtoby/SlackNet/tree/master/SlackNet.Bot#slacknetbot)

--- a/SlackNet.EventsAspNetCoreExample/readme.md
+++ b/SlackNet.EventsAspNetCoreExample/readme.md
@@ -1,3 +1,3 @@
 ﻿# ASP.NET Core 6 Events Example
 
-[Documentation](https://github.com/soxtoby/SlackNet/tree/master/SlackNet.Bot#slacknetbot)
+[Documentation](https://medium.com/@justinshawngerber/how-to-create-a-simple-slackbot-using-c-and-net-6-ebfec7692f41)

--- a/SlackNet.EventsAspNetCoreExample/readme.md
+++ b/SlackNet.EventsAspNetCoreExample/readme.md
@@ -1,0 +1,27 @@
+﻿# ASP.NET Core Events Example
+
+## Slack setup
+
+Start by creating a [Slack app](https://api.slack.com/apps). 
+
+Subscribe to the `message.*` bot events and the `app_home_opened` workspace event.  
+
+Add the following [bot token](https://api.slack.com/authentication/token-types#granular_bot) scopes: `chat:write`, `im:write`.
+
+Once the application is up and running, fill in the event and interactivity request URLs with https://your-app/slack/event and https://your-app/slack/action respectively.
+
+To use the slash command example, create a slash command called `/echo` and point it at https://your-app/slack/command.
+
+To use the workflow example, follow Slack's [Steps from apps](https://api.slack.com/workflows/steps) guide, using `test_step` as the Callback ID when you create the step for your Slack app.
+
+## Project setup
+
+Fill in the `ApiToken` and `SigningSecret` settings in `appsettings.json`.
+
+The application needs to be made publicly available for Slack to be able to interact with it. When running locally, you can use a tool like [ngrok](https://ngrok.com/) get a public URL.
+
+Alternatively, you can switch to socket mode by following the instructions in the [socket mode example](../SlackNet.SocketModeExample/readme.md), and passing `true` into `UseSocketMode` in `Startup.cs`.
+
+## Running the example
+
+Run the `SlackNet.EventsExample` project. It should open a web page with further instructions.

--- a/SlackNet.EventsAspNetCoreExample/readme.md
+++ b/SlackNet.EventsAspNetCoreExample/readme.md
@@ -1,27 +1,3 @@
 ﻿# ASP.NET Core Events Example
 
-## Slack setup
-
-Start by creating a [Slack app](https://api.slack.com/apps). 
-
-Subscribe to the `message.*` bot events and the `app_home_opened` workspace event.  
-
-Add the following [bot token](https://api.slack.com/authentication/token-types#granular_bot) scopes: `chat:write`, `im:write`.
-
-Once the application is up and running, fill in the event and interactivity request URLs with https://your-app/slack/event and https://your-app/slack/action respectively.
-
-To use the slash command example, create a slash command called `/echo` and point it at https://your-app/slack/command.
-
-To use the workflow example, follow Slack's [Steps from apps](https://api.slack.com/workflows/steps) guide, using `test_step` as the Callback ID when you create the step for your Slack app.
-
-## Project setup
-
-Fill in the `ApiToken` and `SigningSecret` settings in `appsettings.json`.
-
-The application needs to be made publicly available for Slack to be able to interact with it. When running locally, you can use a tool like [ngrok](https://ngrok.com/) get a public URL.
-
-Alternatively, you can switch to socket mode by following the instructions in the [socket mode example](../SlackNet.SocketModeExample/readme.md), and passing `true` into `UseSocketMode` in `Startup.cs`.
-
-## Running the example
-
-Run the `SlackNet.EventsExample` project. It should open a web page with further instructions.
+Documentation can be found here https://medium.com/@justinshawngerber/how-to-create-a-simple-slackbot-using-c-and-net-6-ebfec7692f41

--- a/SlackNet.sln
+++ b/SlackNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32319.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{CDDB3A68-F424-4E30-B395-55909E57C530}"
 EndProject
@@ -27,13 +27,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackNet.BotExample", "Slac
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackNet.AzureFunctionExample", "SlackNet.AzureFunctionExample\SlackNet.AzureFunctionExample.csproj", "{BC46F8E3-F021-40EB-94B9-5AEBE69D77F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackNet.SocketModeExample", "SlackNet.SocketModeExample\SlackNet.SocketModeExample.csproj", "{FABAA558-C69F-4F39-9A25-C9A5843D11F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackNet.SocketModeExample", "SlackNet.SocketModeExample\SlackNet.SocketModeExample.csproj", "{FABAA558-C69F-4F39-9A25-C9A5843D11F2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackNet.Autofac", "SlackNet.Autofac\SlackNet.Autofac.csproj", "{F104F95D-DA02-4FEC-B396-6E7ACBD9CBEC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackNet.Autofac", "SlackNet.Autofac\SlackNet.Autofac.csproj", "{F104F95D-DA02-4FEC-B396-6E7ACBD9CBEC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackNet.Extensions.DependencyInjection", "SlackNet.Extensions.DependencyInjection\SlackNet.Extensions.DependencyInjection.csproj", "{E89C1FD1-CCE2-4F3B-9519-764F0E543507}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackNet.Extensions.DependencyInjection", "SlackNet.Extensions.DependencyInjection\SlackNet.Extensions.DependencyInjection.csproj", "{E89C1FD1-CCE2-4F3B-9519-764F0E543507}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackNet.SimpleInjector", "SlackNet.SimpleInjector\SlackNet.SimpleInjector.csproj", "{91BF382B-07E9-4685-9AB8-1B4A780A776A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackNet.SimpleInjector", "SlackNet.SimpleInjector\SlackNet.SimpleInjector.csproj", "{91BF382B-07E9-4685-9AB8-1B4A780A776A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackNet.EventsAspNetCoreExample", "SlackNet.EventsAspNetCoreExample\SlackNet.EventsAspNetCoreExample.csproj", "{1CDE0E26-16AF-413C-A95F-B3C5F02FB576}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +93,10 @@ Global
 		{91BF382B-07E9-4685-9AB8-1B4A780A776A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91BF382B-07E9-4685-9AB8-1B4A780A776A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91BF382B-07E9-4685-9AB8-1B4A780A776A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CDE0E26-16AF-413C-A95F-B3C5F02FB576}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CDE0E26-16AF-413C-A95F-B3C5F02FB576}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CDE0E26-16AF-413C-A95F-B3C5F02FB576}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CDE0E26-16AF-413C-A95F-B3C5F02FB576}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,9 @@ var app = builder.Build();
 app.UseSlackNet(c => c.UseSigningSecret("<your signing secret here>"));
 ```
 
-Add event handler registrations inside the AddSlackNet callback. See the [SlackNet.EventsExample](https://github.com/soxtoby/SlackNet/tree/master/SlackNet.EventsExample) project for more detail.
+ASP.NET Core 6.0 app
+
+Add event handler registrations inside the AddSlackNet callback. See the [SlackNet.EventAspNetCoreExample](https://github.com/soxtoby/SlackNet/tree/master/SlackNet.EventAspNetCoreExample) project for more detail.
 
 #### Developing with Socket Mode
 

--- a/readme.md
+++ b/readme.md
@@ -46,16 +46,17 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 }
 ```
 
-or in the setup of your ASP.NET Core 6.0 app:
+You can also setup your ASP.NET Core Web API in Program.cs:
 ```c#
-builder.Services.AddSlackNet(c => c.UseApiToken("<your OAuth access token here>"));
+var builder = WebApplication.CreateBuilder(args);
+...
+builder.Services.AddSingleton(new SlackEndpointConfiguration().UseSigningSecret("<your signing secret here>"));
+builder.Services.AddSlackNet(c => c.UseApiToken("<your OAuth access token here>").RegisterEventHandler<MessageEvent, PingHandler>());
+...
 var app = builder.Build();
-app.UseSlackNet(c => c.UseSigningSecret("<your signing secret here>"));
+
 ```
-
-ASP.NET Core 6.0 app
-
-Add event handler registrations inside the AddSlackNet callback. See the [SlackNet.EventAspNetCoreExample](https://github.com/soxtoby/SlackNet/tree/master/SlackNet.EventAspNetCoreExample) project for more detail.
+See the [SlackNet.EventAspNetCoreExample](https://github.com/soxtoby/SlackNet/tree/master/SlackNet.EventAspNetCoreExample) project for more detail.
 
 #### Developing with Socket Mode
 


### PR DESCRIPTION
Hello @soxtoby, 

This repository is very helpful! 

The API documentation to use Slack's Event Subscriptions is a bit confusing at the moment. I updated the readme.md and created a new example project in the solution called EventsAspNetCoreExample. There's also a new readme.md inside the EventsAspNetCoreExample folder that outlines how to setup the API ,deploy the API, and configure api.slack.com. The documentation can be found [here](https://medium.com/@justinshawngerber/how-to-create-a-simple-slackbot-using-c-and-net-6-ebfec7692f41).

I would love to get your feedback and am happy to make changes.
