### PR TITLE
fix: allow `Emoji` property to be set

### DIFF
--- a/SlackNet/WebApi/Responses/EmojiResponse.cs
+++ b/SlackNet/WebApi/Responses/EmojiResponse.cs
@@ -4,6 +4,6 @@ namespace SlackNet.WebApi
 {
     class EmojiResponse
     {
-        public Dictionary<string, string> Emoji { get; } = new();
+        public Dictionary<string, string> Emoji { get; set; } = new();
     }
 }


### PR DESCRIPTION
Avoiding the `set` modifier prevent the serializer from setting the value back from the api response