### PR TITLE
fix: missing fields for attachment of type message unfurl

### DIFF
--- a/SlackNet/Interaction/AttachmentUpdateResponse.cs
+++ b/SlackNet/Interaction/AttachmentUpdateResponse.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using SlackNet.Blocks;
+using System.Collections.Generic;
 using System.Linq;
-using SlackNet.Blocks;
 
 namespace SlackNet.Interaction
 {
-    public class AttachmentUpdateResponse: IReadOnlyAttachment
+    public class AttachmentUpdateResponse : IReadOnlyAttachment
     {
         private readonly MessageResponse _response;
 
@@ -13,12 +13,15 @@ namespace SlackNet.Interaction
         public ResponseType ResponseType => _response.ResponseType;
         public bool ReplaceOriginal => _response.ReplaceOriginal;
         public bool DeleteOriginal => _response.DeleteOriginal;
+        public IList<Block> MessageBlocks => Attachment.MessageBlocks;
         public IList<Block> Blocks => Attachment.Blocks;
         public string Color => Attachment.Color;
         public string Id => Attachment.Id;
         public string Fallback => Attachment.Fallback;
         public string Pretext => Attachment.Pretext;
+        public string AuthorId => Attachment.AuthorId;
         public string AuthorName => Attachment.AuthorName;
+        public string AuthorSubname => Attachment.AuthorSubname;
         public string AuthorLink => Attachment.AuthorLink;
         public string AuthorIcon => Attachment.AuthorIcon;
         public string Title => Attachment.Title;
@@ -27,12 +30,17 @@ namespace SlackNet.Interaction
         public IList<Field> Fields => Attachment.Fields;
         public string ImageUrl => Attachment.ImageUrl;
         public string ThumbUrl => Attachment.ThumbUrl;
+        public string FromUrl => Attachment.FromUrl;
         public string Footer => Attachment.Footer;
         public string FooterIcon => Attachment.FooterIcon;
-        public int? Ts => Attachment.Ts;
+        public string Ts => Attachment.Ts;
         public string CallbackId => Attachment.CallbackId;
         public IList<ActionElement> Actions => Attachment.Actions;
 
         private Attachment Attachment => _response.Message.Attachments.First();
+        public string ChannelTeam => Attachment.ChannelTeam;
+        public string ChannelId => Attachment.ChannelId;
+        public bool? IsShare => Attachment.IsShare;
+        public bool? IsMsgUnfurl => Attachment.IsMsgUnfurl;
     }
 }

--- a/SlackNet/Objects/Attachment.cs
+++ b/SlackNet/Objects/Attachment.cs
@@ -9,24 +9,32 @@ namespace SlackNet
     public interface IReadOnlyAttachment
     {
         IList<Block> Blocks { get; }
+        IList<Block> MessageBlocks { get; }
         string Color { get; }
         string Id { get; }
         string Fallback { get; }
         string Pretext { get; }
         string AuthorName { get; }
+        string AuthorSubname { get; }
         string AuthorLink { get; }
         string AuthorIcon { get; }
+        string AuthorId { get; }
         string Title { get; }
         string TitleLink { get; }
         string Text { get; }
         IList<Field> Fields { get; }
         string ImageUrl { get; }
         string ThumbUrl { get; }
+        string FromUrl { get; }
         string Footer { get; }
         string FooterIcon { get; }
-        int? Ts { get; }
+        string Ts { get; }
         string CallbackId { get; }
         IList<ActionElement> Actions { get; }
+        string ChannelTeam { get; }
+        string ChannelId { get; }
+        bool? IsShare { get; }
+        bool? IsMsgUnfurl { get; }
     }
 
     public class Attachment : IReadOnlyAttachment
@@ -36,13 +44,17 @@ namespace SlackNet
         /// </summary>
         [IgnoreIfEmpty]
         public IList<Block> Blocks { get; set; } = new List<Block>();
+        [IgnoreIfEmpty]
+        public IList<Block> MessageBlocks { get; set; } = new List<Block>();
         public string Color { get; set; }
         public string Id { get; set; }
         public string Fallback { get; set; }
         public string Pretext { get; set; }
         public string AuthorName { get; set; }
+        public string AuthorSubname { get; set; }
         public string AuthorLink { get; set; }
         public string AuthorIcon { get; set; }
+        public string AuthorId { get; set; }
         public string AttachmentType { get; set; }
         public string Title { get; set; }
         public string TitleLink { get; set; }
@@ -51,13 +63,18 @@ namespace SlackNet
         public IList<Field> Fields { get; set; } = new List<Field>();
         public string ImageUrl { get; set; }
         public string ThumbUrl { get; set; }
+        public string FromUrl { get; set; }
         public string Footer { get; set; }
         public string FooterIcon { get; set; }
-        public int? Ts { get; set; }
+        public string Ts { get; set; }
         [JsonIgnore]
         public DateTime? Timestamp => Ts?.ToDateTime().GetValueOrDefault();
         public string CallbackId { get; set; }
         [IgnoreIfEmpty]
         public IList<ActionElement> Actions { get; set; } = new List<ActionElement>();
+        public string ChannelTeam { get; set; }
+        public string ChannelId { get; set; }
+        public bool? IsShare { get; set; }
+        public bool? IsMsgUnfurl { get; set; }
     }
 }


### PR DESCRIPTION
This PR is to propose adding missing fields for the `Attachment` object that returns from the api when the attachment is of type message unfurl (shared message). 
I also fixed the TS type that seems to be returned as a `double` represented as `string` (like in `MessageEvent`) 
The image below shows the response as returned from the api:
![image](https://user-images.githubusercontent.com/54630488/190892742-51603f75-c1c1-4782-a0f7-b0da9991c3bd.png)

I thought to create a special type for this kind of attachments, but unfortunately Slack doesn't expose a `type` field to distinguish between the attachments. So i just overloaded the extra properties.

Let me know if that's ok