### PR TITLE
SlashCommand has TeamDomain instead of TeamName

### DIFF
--- a/SlackNet/Interaction/SlashCommand.cs
+++ b/SlackNet/Interaction/SlashCommand.cs
@@ -43,7 +43,7 @@ namespace SlackNet.Interaction
         public string UserName { get; set; }
 
         public string TeamId { get; set; }
-        public string TeamName { get; set; }
+        public string TeamDomain { get; set; }
 
         public string EnterpriseId { get; set; }
         public string EnterpriseName { get; set; }


### PR DESCRIPTION
There is no team_name field in the parameters of slash commands, there is team_domain instead.
The example in https://api.slack.com/interactivity/slash-commands#app_command_handling shows this correctly, while the description of the fields are misleading.