### PR TITLE
add unicode to the emoji section element

### DIFF
--- a/SlackNet/Blocks/RichTextBlock.cs
+++ b/SlackNet/Blocks/RichTextBlock.cs
@@ -51,7 +51,8 @@ public class RichTextUser : RichTextSectionElement
 public class RichTextEmoji : RichTextSectionElement
 {
     public string Name { get; set; }
-    public string Unicode { get; set; }
+    public string Unicode { get; set; } 
+    public int? SkinTone { get; set; }
 }
 
 [SlackType("link")]

--- a/SlackNet/Blocks/RichTextBlock.cs
+++ b/SlackNet/Blocks/RichTextBlock.cs
@@ -51,6 +51,7 @@ public class RichTextUser : RichTextSectionElement
 public class RichTextEmoji : RichTextSectionElement
 {
     public string Name { get; set; }
+    public string Unicode { get; set; }
 }
 
 [SlackType("link")]


### PR DESCRIPTION
The definition for the RichTextEmoji is incorrect, it should include the Unicode as well. Since that is what the response will contain if it is not a custom emoji. In cases of a custom emoji this field will not be available.

Here is an sample of the response, executed from Postman:

![image](https://user-images.githubusercontent.com/31168388/207307018-5d82f758-cd1e-43aa-b28d-46d4725ab413.png)
