### PR TITLE
Add EnterpriseId to EventCallback

### DIFF
--- a/SlackNet/Events/EventCallback.cs
+++ b/SlackNet/Events/EventCallback.cs
@@ -10,6 +10,7 @@ namespace SlackNet.Events;
 public class EventCallback : EventRequest
 {
     public string TeamId { get; set; }
+    public string EnterpriseId { get; set; }
     public string ApiAppId { get; set; }
     public Event Event { get; set; }
     public IList<Authorization> Authorizations { get; set; }


### PR DESCRIPTION
Add EnterpriseId, that is returned in e.g. these two events:
- https://api.slack.com/events/team_access_granted
- https://api.slack.com/events/team_access_revoked

I did not add these two events to SlackNet, but can amend this PR, if you see it is ok.