### PR TITLE
include ApiAppId in user profile

### DIFF
--- a/SlackNet/Objects/UserProfile.cs
+++ b/SlackNet/Objects/UserProfile.cs
@@ -5,6 +5,7 @@ namespace SlackNet;
 
 public class UserProfile
 {
+    public string ApiAppId { get; set; }
     public string Title { get; set; }
     public string AvatarHash { get; set; }
     public string StatusEmoji { get; set; }


### PR DESCRIPTION
The property api_app_id is missing in the response of the UserProfile object.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/31168388/208688040-9cc8d3e4-c02c-43da-9c8a-df88aadcbf25.png">