### PR TITLE
add border field to RichTextList

### DIFF
--- a/SlackNet/Blocks/RichTextBlock.cs
+++ b/SlackNet/Blocks/RichTextBlock.cs
@@ -98,6 +98,7 @@ public class RichTextList : RichTextElement
     public IList<RichTextElement> Elements { get; set; } = new List<RichTextElement>();
     public string Style { get; set; }
     public int Indent { get; set; }
+    public int Border { get; set; }
 }
 
 public class RichTextQuote : RichTextElement


### PR DESCRIPTION
The type for the rich text list is incomplete:

![image](https://user-images.githubusercontent.com/31168388/209331817-79c5a53e-7f6a-4f22-9a81-d949fa551c18.png)

In this PR I've added the missing Border filed.