### PR TITLE
fix: StringResult should return a content type

### DIFF
--- a/SlackNet.AspNetCore/SlackResult.cs
+++ b/SlackNet.AspNetCore/SlackResult.cs
@@ -58,6 +58,7 @@ class StringResult : SlackResult
     public StringResult(HttpStatusCode status, string body)
         : base(status) => Body = body;
 
+    protected override string ContentType => "text/plain";
     protected override string Body { get; }
 }
 


### PR DESCRIPTION
During the process of Event Subscription Event Challenge, the return payload must contains a content-type. If not, it's will fail the Verified Challenge.

![image](https://user-images.githubusercontent.com/11981907/217633232-f092b5e1-145b-41a4-a79a-8b2193e12a79.png)

Adding the Content Type: "text/plain" make it success.

https://api.slack.com/events/url_verification