### PR TITLE
Including missing huddle properties on the UserProfile object

### DIFF
--- a/SlackNet/Objects/UserProfile.cs
+++ b/SlackNet/Objects/UserProfile.cs
@@ -17,6 +17,8 @@ public class UserProfile
     public string RealNameNormalized { get; set; }
     public string DisplayName { get; set; }
     public string Email { get; set; }
+    public string HuddleState { get; set; }
+    public int HuddleStateExpirationTs { get; set; }
     public string Skype { get; set; }
     public string Phone { get; set; }
     public bool? AlwaysActive { get; set; }


### PR DESCRIPTION
According to [slack docs](https://api.slack.com/types/user), the UserProfile object includes:

```
"huddle_state": "default_unset",
"huddle_state_expiration_ts": 0,
```

