### PR TITLE
[ENH] Adds additional user change events

### DIFF
--- a/SlackNet/Events/UserHuddleChanged.cs
+++ b/SlackNet/Events/UserHuddleChanged.cs
@@ -1,0 +1,9 @@
+namespace SlackNet.Events
+{
+    /// <summary>
+    /// Sent to all connections for a workspace when a user's huddle status is changed.
+    /// </summary>
+    public class UserHuddleChanged : UserChange
+    {
+    }
+}

--- a/SlackNet/Events/UserProfileChanged.cs
+++ b/SlackNet/Events/UserProfileChanged.cs
@@ -1,0 +1,9 @@
+namespace SlackNet.Events
+{
+    /// <summary>
+    /// Sent to all connections for a workspace when a user's profile data is changed.
+    /// </summary>
+    public class UserProfileChanged : UserChange
+    {
+    }
+}

--- a/SlackNet/Events/UserStatusChanged.cs
+++ b/SlackNet/Events/UserStatusChanged.cs
@@ -1,0 +1,9 @@
+namespace SlackNet.Events
+{
+    /// <summary>
+    /// Sent to all connections for a workspace when a user's status is changed.
+    /// </summary>
+    public class UserStatusChanged : UserChange
+    {
+    }
+}


### PR DESCRIPTION
As stated in [Slack docs](https://api.slack.com/events/user_change), the `user_change` event is emitted when one of three possible things happens:

> Depending on what event took place, one of the following three other events will be dispatched simultaneously:
> 
> [user_huddle_changed](https://api.slack.com/events/user_huddle_changed), when a user's huddle status changes
> [user_profile_changed](https://api.slack.com/events/user_profile_changed), when a user's profile data changes
> [user_status_changed](https://api.slack.com/events/user_status_changed), when a user's status changes

Those events are currently not present in SlackNET, so we don't have a way to react to them directly and granularly. 


Since docs explicitly state that these events are _identical to the existing user_change event_ I've inherited `UserChange`. @soxtoby if that breaks the pattern in any way I can correct that and define them individually. 