### PR TITLE
Write FocusOnLoad only when not default because ExternalMultiSelectMenu does not support it

### DIFF
--- a/SlackNet/Blocks/SelectMenuBase.cs
+++ b/SlackNet/Blocks/SelectMenuBase.cs
@@ -12,5 +12,6 @@ public abstract class SelectMenuBase : ActionElement, IInputBlockElement
     /// <summary>
     /// Indicates whether the element will be set to auto focus within the <see cref="ViewInfo"/> object. Only one element can be set to true.
     /// </summary>
+    [IgnoreIfDefault] // See issue #177 - Slack returns an invalid parameter for ExternalMultiSelectMenu
     public bool FocusOnLoad { get; set; }
 }


### PR DESCRIPTION
This is a suggestion for resolving issue [#177](https://github.com/soxtoby/SlackNet/issues/177) (ignoring FocusOnLoad in serialization in order to use ExternalMultiSelectMenu)

Let me know if it makes sense.