### PR TITLE
Changing response type for Chat.PostEphemeral

### DIFF
--- a/SlackNet.Bot/SlackBot.cs
+++ b/SlackNet.Bot/SlackBot.cs
@@ -492,9 +492,20 @@ namespace SlackNet.Bot
                     AsUser = true
                 };
 
-            return message.Ephemeral
-                ? await _api.Chat.PostEphemeral(message.ReplyTo.User.Id, slackMessage, message.CancellationToken).ConfigureAwait(false)
-                : await _api.Chat.PostMessage(slackMessage, message.CancellationToken).ConfigureAwait(false);
+            if (message.Ephemeral)
+            {
+                PostEphemeralResponse response = await _api.Chat.PostEphemeral(message.ReplyTo.User.Id, slackMessage, message.CancellationToken).ConfigureAwait(false);
+
+                // for backwards compatibility, convert to the other type and supply the correct information
+                // which is more than null values for each
+                return new PostMessageResponse
+                {
+                    Ts = response.MessageTs,
+                    Channel = slackMessage.Channel
+                };
+            }
+
+            return await _api.Chat.PostMessage(slackMessage, message.CancellationToken).ConfigureAwait(false);
         }
 
         private async Task<bool> ReplyingInDifferentHub(BotMessage message) =>

--- a/SlackNet/WebApi/ChatApi.cs
+++ b/SlackNet/WebApi/ChatApi.cs
@@ -63,7 +63,7 @@ public interface IChatApi
     /// <param name="userId">ID of the user who will receive the ephemeral message. The user should be in the channel specified by the channel argument.</param>
     /// <param name="message">The message to post. Not all message properties are supported by <c>PostEphemeral</c>.</param>
     /// <param name="cancellationToken"></param>
-    Task<PostMessageResponse> PostEphemeral(string userId, Message message, CancellationToken? cancellationToken = null);
+    Task<PostEphemeralResponse> PostEphemeral(string userId, Message message, CancellationToken? cancellationToken = null);
 
     /// <summary>
     /// Attaches Slack app unfurl behavior to a specified and relevant message.
@@ -218,8 +218,8 @@ public class ChatApi : IChatApi
                 },
             cancellationToken);
 
-    public Task<PostMessageResponse> PostEphemeral(string userId, Message message, CancellationToken? cancellationToken = null) =>
-        _client.Post<PostMessageResponse>("chat.postEphemeral", new Args
+    public Task<PostEphemeralResponse> PostEphemeral(string userId, Message message, CancellationToken? cancellationToken = null) =>
+        _client.Post<PostEphemeralResponse>("chat.postEphemeral", new Args
                 {
                     { "channel", message.Channel },
                     { "text", message.Text },


### PR DESCRIPTION
Breaking change fix to return the correct response type for PostEphemeral.

Referencing bug #183 