### PR TITLE
feat(auth): Created TeamsList Request

### DIFF
--- a/SlackNet/WebApi/AuthApi.cs
+++ b/SlackNet/WebApi/AuthApi.cs
@@ -22,6 +22,16 @@ public interface IAuthApi
     /// <remarks>See the <a href="https://api.slack.com/methods/auth.test">Slack documentation</a> for more information.</remarks>
     /// <param name="cancellationToken"></param>
     Task<AuthTestResponse> Test(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtain a full list of workspaces your org-wide app has been approved for.
+    /// </summary>
+    /// <remarks>See the <a href="https://api.slack.com/methods/auth.teams.list">Slack documentation</a> for more information.</remarks>
+    /// <param name="cursor">Set cursor to next_cursor returned by the previous call to list items in the next page.</param>
+    /// <param name="includeIcon">Whether to return icon paths for each workspace. An icon path represents a URI pointing to the image signifying the workspace.</param>
+    /// <param name="limit">The maximum number of workspaces to return. Must be a positive integer no larger than 1000.</param>
+    /// <param name="cancellationToken"></param>
+    Task<AuthTeamsListResponse> TeamsList(string cursor = null, bool includeIcon = false, int limit = 100, CancellationToken cancellationToken = default);
 }
 
 public class AuthApi : IAuthApi
@@ -34,4 +44,12 @@ public class AuthApi : IAuthApi
 
     public Task<AuthTestResponse> Test(CancellationToken cancellationToken = default) =>
         _client.Post<AuthTestResponse>("auth.test", new Args(), cancellationToken);
+
+    public Task<AuthTeamsListResponse> TeamsList(string cursor = null, bool includeIcon = false, int limit = 100, CancellationToken cancellationToken = default) =>
+        _client.Get<AuthTeamsListResponse>("auth.teams.list", new Args
+            {
+                { "cursor", cursor },
+                { "include_icon", includeIcon },
+                { "limit", limit }
+            }, cancellationToken);
 }

--- a/SlackNet/WebApi/Responses/AuthTeamsListResponse.cs
+++ b/SlackNet/WebApi/Responses/AuthTeamsListResponse.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace SlackNet.WebApi;
+
+public class AuthTeamsListResponse
+{
+    public IList<AuthTeam> Teams { get; set; } = [];
+    public ResponseMetadata ResponseMetadata { get; set; } = new();
+}
+
+public class AuthTeam
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public string Icon { get; set; }
+} 


### PR DESCRIPTION
We have a use case that requires us to identify all the teams that have installed our app within a specific organization.
It seems that Slack provides a method to do so, but it was missing from this library.

https://api.slack.com/methods/auth.teams.list - Obtain a full list of workspaces your org-wide app has been approved for.

I tried following the other auth methods when creating this one. I'd be grateful for your help and collaboration on this matter. @soxtoby